### PR TITLE
Alfredapi 387

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.1 (Unreleased)
 ## Changed
 * [ALFREDAPI-385](https://xenitsupport.jira.com/browse/ALFREDAPI-385): Change docker & compose files for integration tests to use harbor
+* [ALFREDAPI-387](https://xenitsupport.jira.com/browse/ALFREDAPI-387): Add existence check and 404 to working copies endpoint
 
 ## 2.2.0 (2019-09-17)
 

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/workingcopies/WorkingcopiesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/workingcopies/WorkingcopiesWebscript1.java
@@ -49,17 +49,19 @@ public class WorkingcopiesWebscript1 extends ApixV1Webscript {
     public void createWorkingcopy(CheckoutBody checkoutBody, WebScriptResponse response) throws IOException {
         final NodeRef originalRef = checkoutBody.getOriginal();
         NodeRef destinationRef = checkoutBody.getDestinationFolder();
-        String message = String.format("Original noderef %s", originalRef);
+
         if (nodeService.exists(originalRef)) {
-            final NodeRef finalDestinationRef = destinationRef;
-            message = String.format("Destination noderef %s", finalDestinationRef);
-            if (nodeService.exists(finalDestinationRef)) {
-                NodeRef workingCopyRef = nodeService.checkout(originalRef, finalDestinationRef);
+            // if a destinationRef was specified, it must exist, but nodeservice.checkout(..., null) works fine.
+            if (destinationRef == null || nodeService.exists(destinationRef)) {
+                NodeRef workingCopyRef = nodeService.checkout(originalRef, destinationRef);
                 writeJsonResponse(response, new NoderefResult(workingCopyRef));
+            } else {
+                response.setStatus(404);
+                response.getWriter().write(String.format("Destination noderef %s does not exist", destinationRef));
             }
         } else {
             response.setStatus(404);
-            response.getWriter().write(String.format("%s does not exist.", message));
+            response.getWriter().write(String.format("Original noderef %s does not exist.", originalRef));
         }
     }
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-387

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses. --> API change: added/changed 500 response to 404 response
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
