### PR TITLE
ALFREDAPI-385 Use maintained images for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Alfred API - Changelog
 
-## 2.2.1 (Unreleased)
+## 2.3.0 (Unreleased)
 ## Changed
-* [ALFREDAPI-385](https://xenitsupport.jira.com/browse/ALFREDAPI-385): Change docker & compose files for integration tests to use harbor
+* [ALFREDAPI-385](https://xenitsupport.jira.com/browse/ALFREDAPI-385): Change docker & compose files for integration tests to use harbor and docker.io/xenit
 * [ALFREDAPI-387](https://xenitsupport.jira.com/browse/ALFREDAPI-387): Add existence check and 404 to working copies endpoint
 
 ## 2.2.0 (2019-09-17)
@@ -22,7 +22,7 @@
 * [ALFREDAPI-380](https://xenitsupport.jira.com/browse/ALFREDAPI-380): Disable archiving of Jenkins artefacts
 
 ### Fixed
-* [ALFREDAPI-325](https://xenitsupport.jira.com/browse/ALFREDAPI-325): HTTP 500 when requesting a dictionary definition with unregisterd namespace 
+* [ALFREDAPI-325](https://xenitsupport.jira.com/browse/ALFREDAPI-325): HTTP 500 when requesting a dictionary definition with unregisterd namespace
 * [ALFREDAPI-349](https://xenitsupport.jira.com/browse/ALFREDAPI-349): 500 Internal Error upon order by parties
 * [ALFREDAPI-357](https://xenitsupport.jira.com/browse/ALFREDAPI-357): Query with special character in it (e.g. - or {) causes 500 exception
 * [ALFREDAPI-381](https://xenitsupport.jira.com/browse/ALFREDAPI-381): Changing the name of a node now also updates the qname path
@@ -57,7 +57,7 @@ with Alfresco 6.0. It is not yet intended for production.
 
 ### Added
 * [ALFREDAPI-291](https://xenitsupport.jira.com/browse/ALFREDAPI-291): Expose Java MimetypeService
- 
+
 ### Changed
 * [ALFREDAPI-361](https://xenitsupport.jira.com/browse/ALFREDAPI-361): Create multiple release branches
 

--- a/apix-docker/50/docker-compose.yml
+++ b/apix-docker/50/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     - JAVA_XMX=2048M
 
   postgresql:
-    image: docker.io/xeniteu/postgres:9.4
+    image: docker.io/xenit/postgres
     volumes:
     - postgres:/var/lib/postgresql/data
     environment:

--- a/apix-docker/51/docker-compose.yml
+++ b/apix-docker/51/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     - JAVA_XMX=2048M
 
   postgresql:
-    image: docker.io/xeniteu/postgres:10.10
+    image: docker.io/xenit/postgres
     volumes:
     - postgres:/var/lib/postgresql/data
     environment:

--- a/apix-docker/52/docker-compose.yml
+++ b/apix-docker/52/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - ALFRESCO_HOST=alfresco-core
 
   postgresql:
-    image: docker.io/xeniteu/postgres:10.10
+    image: docker.io/xenit/postgres
     volumes:
     - postgres:/var/lib/postgresql/data
     environment:

--- a/apix-docker/60/docker-compose.yml
+++ b/apix-docker/60/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - ALFRESCO_HOST=alfresco-core
 
   postgresql:
-    image: docker.io/xeniteu/postgres:10.10
+    image: docker.io/xenit/postgres
     volumes:
     - postgres:/var/lib/postgresql/data
     environment:

--- a/apix-docker/61/docker-compose.yml
+++ b/apix-docker/61/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     - ALFRESCO_HOST=alfresco-core
 
   postgresql:
-    image: docker.io/xeniteu/postgres:10.10
+    image: docker.io/xenit/postgres
     volumes:
     - postgres:/var/lib/postgresql/data
     environment:

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ buildscript {
 }
 
 ext {
-    versionWithoutQualifier = '2.2.0'
+    versionWithoutQualifier = '2.3.0'
     
     jackson_version = '2.6.3'
     swagger_version = "1.5.7"


### PR DESCRIPTION
The primary publishing account of our docker images  has changed from [/u/xeniteu](https://hub.docker.com/u/xeniteu) to [/u/xenit](https://hub.docker.com/u/xenit), and the former will likely be deleted soon. This PR updates the relevant images (only postgres) to the new publishing account, and implicitly uses `:latest`, which is recommended for integration tests' postgres.

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
