### PR TITLE
Remove dependency on private artifactory for buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,20 +32,6 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
-        maven {
-            url 'https://artifactory.xenit.eu/artifactory/libs-snapshot'
-            credentials {
-                username property("eu.xenit.artifactory.username")
-                password property("eu.xenit.artifactory.password")
-            }
-        }
-        maven {
-            url 'https://artifactory.xenit.eu/artifactory/libs-release'
-            credentials {
-                username property("eu.xenit.artifactory.username")
-                password property("eu.xenit.artifactory.password")
-            }
-        }
     }
 }
 


### PR DESCRIPTION
The Xenit private artifactory is listed as a repository in `buildscript{ }`.
Since all used plugins are open source and published to gradle plugin portal or other repositories, these private repositories can be removed.