### PR TITLE
Use correct docker image for Solr in 6.0 test

### DIFF
--- a/apix-docker/60/docker-compose.yml
+++ b/apix-docker/60/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - SOLR_HOST=solr
 
   solr:
-    image: hub.xenit.eu/alfresco-solr6:1.2.0
+    image: hub.xenit.eu/alfresco-enterprise/alfresco-solr6:1.2.0
     restart: unless-stopped
     environment:
     - ALFRESCO_HOST=alfresco-core


### PR DESCRIPTION
The docker-compose for the 6.0 was still using the old reference to the docker image for Solr.

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
