### PR TITLE
ALFREDAPI-410 wrap Data Dictionary lookup with runAsSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* [ALFREDAPI-410](https://xenitsupport.jira.com/browse/ALFREDAPI-410): Configuration webscript requires read access to Company Home
 
 ### Deleted
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/configuration/ConfigurationServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/configuration/ConfigurationServiceImpl.java
@@ -18,6 +18,7 @@ import eu.xenit.apix.node.ChildParentAssociation;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.node.NodeMetadata;
 import eu.xenit.apix.rest.v1.configuration.ConfigurationWebscript1;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +61,8 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         }
         String[] searchDirectoryParts = searchDirectory.split("/");
 
-        NodeRef rootFolder = fileFolderService.getDataDictionary();
+        // Running as system so user does not need read access on the folders in between
+        NodeRef rootFolder = AuthenticationUtil.runAsSystem(() -> fileFolderService.getDataDictionary());
         logger.debug("Looking up directory {} inside datadictionary {}", searchDirectory, rootFolder);
 
         NodeRef searchDirectoryRef = rootFolder;


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-410

- [ X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?
