### PR TITLE
ALFREDAPI-416 Removed max repository version from module.properties for builds for most recent Alfresco 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [HA-29](https://xenitsupport.jira.com/browse/HA-29): Added webscript for retrieving available sites + webscript for retrieving ancestors of a node
 
 ### Changed
+* [ALFREDAPI-416](https://xenitsupport.jira.com/browse/ALFREDAPI-416): Removed max repository version from module.properties for builds for most recent Alfresco
 
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint

--- a/apix-impl/50/overrides.gradle
+++ b/apix-impl/50/overrides.gradle
@@ -3,4 +3,6 @@ description = "Xenit API-X implementation Alfresco 5.0"
 ext {
     alfresco_version = alfresco_50_version
     alfresco_dm_version = alfresco_50_dm_version
+    alfresco_min_version = alfresco_50_min_version
+    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/50/overrides.gradle
+++ b/apix-impl/50/overrides.gradle
@@ -3,6 +3,6 @@ description = "Xenit API-X implementation Alfresco 5.0"
 ext {
     alfresco_version = alfresco_50_version
     alfresco_dm_version = alfresco_50_dm_version
-    alfresco_min_version = alfresco_50_min_version
+    alfresco_min_version = "5.0"
     alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/50/overrides.gradle
+++ b/apix-impl/50/overrides.gradle
@@ -4,5 +4,5 @@ ext {
     alfresco_version = alfresco_50_version
     alfresco_dm_version = alfresco_50_dm_version
     alfresco_min_version = "5.0"
-    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
+    alfresco_max_version = "5.0.99"
 }

--- a/apix-impl/50/src/main/config/module.properties
+++ b/apix-impl/50/src/main/config/module.properties
@@ -3,5 +3,5 @@ module.title=${project.name}
 module.description=${project.description}
 module.version=${project.version}
 
-module.repo.version.min=5.0
-module.repo.version.max=5.0.99
+module.repo.version.min=${project.alfresco_min_version}
+module.repo.version.max=${project.properties["alfresco_max_version"]}

--- a/apix-impl/50/src/main/config/module.properties
+++ b/apix-impl/50/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties["alfresco_max_version"]}
+module.repo.version.max=${project.properties.alfresco_max_version}

--- a/apix-impl/50/src/main/config/module.properties
+++ b/apix-impl/50/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties.alfresco_max_version}
+module.repo.version.max=${project.alfresco_max_version}

--- a/apix-impl/51/overrides.gradle
+++ b/apix-impl/51/overrides.gradle
@@ -3,6 +3,6 @@ description = "Xenit API-X implementation Alfresco 5.1"
 ext {
     alfresco_version = alfresco_51_version
     alfresco_dm_version = alfresco_51_dm_version
-    alfresco_min_version = alfresco_51_min_version
+    alfresco_min_version = "5.1"
     alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/51/overrides.gradle
+++ b/apix-impl/51/overrides.gradle
@@ -3,4 +3,6 @@ description = "Xenit API-X implementation Alfresco 5.1"
 ext {
     alfresco_version = alfresco_51_version
     alfresco_dm_version = alfresco_51_dm_version
+    alfresco_min_version = alfresco_51_min_version
+    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/51/overrides.gradle
+++ b/apix-impl/51/overrides.gradle
@@ -4,5 +4,5 @@ ext {
     alfresco_version = alfresco_51_version
     alfresco_dm_version = alfresco_51_dm_version
     alfresco_min_version = "5.1"
-    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
+    alfresco_max_version = "5.1.99"
 }

--- a/apix-impl/51/src/main/config/module.properties
+++ b/apix-impl/51/src/main/config/module.properties
@@ -3,5 +3,5 @@ module.title=${project.name}
 module.description=${project.description}
 module.version=${project.version}
 
-module.repo.version.min=5.1
-module.repo.version.max=5.1.99
+module.repo.version.min=${project.alfresco_min_version}
+module.repo.version.max=${project.properties["alfresco_max_version"]}

--- a/apix-impl/51/src/main/config/module.properties
+++ b/apix-impl/51/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties["alfresco_max_version"]}
+module.repo.version.max=${project.properties.alfresco_max_version}

--- a/apix-impl/51/src/main/config/module.properties
+++ b/apix-impl/51/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties.alfresco_max_version}
+module.repo.version.max=${project.alfresco_max_version}

--- a/apix-impl/52/overrides.gradle
+++ b/apix-impl/52/overrides.gradle
@@ -4,5 +4,5 @@ ext {
     alfresco_version = alfresco_52_version
     alfresco_dm_version = alfresco_52_dm_version
     alfresco_min_version = "5.2"
-    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
+    alfresco_max_version = "5.2.99"
 }

--- a/apix-impl/52/overrides.gradle
+++ b/apix-impl/52/overrides.gradle
@@ -3,6 +3,6 @@ description = "Xenit API-X implementation Alfresco 5.2"
 ext {
     alfresco_version = alfresco_52_version
     alfresco_dm_version = alfresco_52_dm_version
-    alfresco_min_version = alfresco_52_min_version
+    alfresco_min_version = "5.2"
     alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/52/overrides.gradle
+++ b/apix-impl/52/overrides.gradle
@@ -3,4 +3,6 @@ description = "Xenit API-X implementation Alfresco 5.2"
 ext {
     alfresco_version = alfresco_52_version
     alfresco_dm_version = alfresco_52_dm_version
+    alfresco_min_version = alfresco_52_min_version
+    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/52/src/main/config/module.properties
+++ b/apix-impl/52/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties["alfresco_max_version"]}
+module.repo.version.max=${project.properties.alfresco_max_version}

--- a/apix-impl/52/src/main/config/module.properties
+++ b/apix-impl/52/src/main/config/module.properties
@@ -3,5 +3,5 @@ module.title=${project.name}
 module.description=${project.description}
 module.version=${project.version}
 
-module.repo.version.min=5.2
-module.repo.version.max=5.2.99
+module.repo.version.min=${project.alfresco_min_version}
+module.repo.version.max=${project.properties["alfresco_max_version"]}

--- a/apix-impl/52/src/main/config/module.properties
+++ b/apix-impl/52/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties.alfresco_max_version}
+module.repo.version.max=${project.alfresco_max_version}

--- a/apix-impl/60/overrides.gradle
+++ b/apix-impl/60/overrides.gradle
@@ -3,6 +3,6 @@ description = "Xenit API-X implementation Alfresco 6.0"
 ext {
     alfresco_version = alfresco_60_version
     alfresco_dm_version = alfresco_60_dm_version
-    alfresco_min_version = alfresco_60_min_version
+    alfresco_min_version = "6.0"
     alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/60/overrides.gradle
+++ b/apix-impl/60/overrides.gradle
@@ -4,5 +4,5 @@ ext {
     alfresco_version = alfresco_60_version
     alfresco_dm_version = alfresco_60_dm_version
     alfresco_min_version = "6.0"
-    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
+    alfresco_max_version = "6.0.99"
 }

--- a/apix-impl/60/overrides.gradle
+++ b/apix-impl/60/overrides.gradle
@@ -3,4 +3,6 @@ description = "Xenit API-X implementation Alfresco 6.0"
 ext {
     alfresco_version = alfresco_60_version
     alfresco_dm_version = alfresco_60_dm_version
+    alfresco_min_version = alfresco_60_min_version
+    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/60/src/main/config/module.properties
+++ b/apix-impl/60/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties["alfresco_max_version"]}
+module.repo.version.max=${project.properties.alfresco_max_version}

--- a/apix-impl/60/src/main/config/module.properties
+++ b/apix-impl/60/src/main/config/module.properties
@@ -3,5 +3,5 @@ module.title=${project.name}
 module.description=${project.description}
 module.version=${project.version}
 
-module.repo.version.min=6.0
-module.repo.version.max=6.0.99
+module.repo.version.min=${project.alfresco_min_version}
+module.repo.version.max=${project.properties["alfresco_max_version"]}

--- a/apix-impl/60/src/main/config/module.properties
+++ b/apix-impl/60/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties.alfresco_max_version}
+module.repo.version.max=${project.alfresco_max_version}

--- a/apix-impl/61/overrides.gradle
+++ b/apix-impl/61/overrides.gradle
@@ -4,5 +4,4 @@ ext {
     alfresco_version = alfresco_61_version
     alfresco_dm_version = alfresco_61_dm_version
     alfresco_min_version = "6.1"
-    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/61/overrides.gradle
+++ b/apix-impl/61/overrides.gradle
@@ -4,4 +4,5 @@ ext {
     alfresco_version = alfresco_61_version
     alfresco_dm_version = alfresco_61_dm_version
     alfresco_min_version = "6.1"
+    //Not setting alfresco_max_version here to make it easier to test on next Alfresco version (only for latest version)
 }

--- a/apix-impl/61/overrides.gradle
+++ b/apix-impl/61/overrides.gradle
@@ -3,4 +3,6 @@ description = "Xenit API-X implementation Alfresco 6.1"
 ext {
     alfresco_version = alfresco_61_version
     alfresco_dm_version = alfresco_61_dm_version
+    alfresco_min_version = alfresco_61_min_version
+    alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/61/overrides.gradle
+++ b/apix-impl/61/overrides.gradle
@@ -3,6 +3,6 @@ description = "Xenit API-X implementation Alfresco 6.1"
 ext {
     alfresco_version = alfresco_61_version
     alfresco_dm_version = alfresco_61_dm_version
-    alfresco_min_version = alfresco_61_min_version
+    alfresco_min_version = "6.1"
     alfresco_max_version = getMaxRepositoryVersionRequirement(project, alfresco_min_version)
 }

--- a/apix-impl/61/src/main/config/module.properties
+++ b/apix-impl/61/src/main/config/module.properties
@@ -4,4 +4,3 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties.alfresco_max_version}

--- a/apix-impl/61/src/main/config/module.properties
+++ b/apix-impl/61/src/main/config/module.properties
@@ -3,5 +3,5 @@ module.title=${project.name}
 module.description=${project.description}
 module.version=${project.version}
 
-module.repo.version.min=6.1
-module.repo.version.max=6.1.99
+module.repo.version.min=${project.alfresco_min_version}
+module.repo.version.max=${project.properties["alfresco_max_version"]}

--- a/apix-impl/61/src/main/config/module.properties
+++ b/apix-impl/61/src/main/config/module.properties
@@ -4,4 +4,4 @@ module.description=${project.description}
 module.version=${project.version}
 
 module.repo.version.min=${project.alfresco_min_version}
-module.repo.version.max=${project.properties["alfresco_max_version"]}
+module.repo.version.max=${project.properties.alfresco_max_version}

--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -4,23 +4,6 @@ plugins {
     id 'eu.xenit.alfresco' version '1.0.0' apply false
 }
 
-String getMaxRepositoryVersionRequirement(Project currentProject, String minAlfrescoVersion) {
-    Comparator<Project> comparator = new Comparator<Project>() {
-        @Override
-        int compare(Project p1, Project p2) {
-            return p1.name.compareTo(p2.name)
-        }
-    }
-
-    List<Project> subProjectList = subprojects.toSorted(comparator)
-
-    if (currentProject.getName().equals(subProjectList.last().getName())) {
-        return ""
-    }
-
-    return minAlfrescoVersion + ".99"
-}
-
 subprojects {
     apply from: "${rootProject.projectDir}/publish.gradle"
     apply from: "${project.projectDir}/overrides.gradle"

--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'eu.xenit.alfresco' version '1.0.0' apply false
 }
 
-String getMaxRepositoryVersionRequirement(Project currentProject, String minAlfrescoVersion){
+String getMaxRepositoryVersionRequirement(Project currentProject, String minAlfrescoVersion) {
     Comparator<Project> comparator = new Comparator<Project>() {
         @Override
         int compare(Project p1, Project p2) {

--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -4,6 +4,31 @@ plugins {
     id 'eu.xenit.alfresco' version '1.0.0' apply false
 }
 
+String getMaxRepositoryVersionRequirement(Project currentProject, String minAlfrescoVersion){
+    Comparator<Project> comparator = new Comparator<Project>() {
+        @Override
+        int compare(Project p1, Project p2) {
+            return p1.name.compareTo(p2.name)
+        }
+    }
+
+    List<Project> subProjectList = subprojects.toSorted(comparator)
+
+    if (currentProject.getName().equals(subProjectList.last().getName())) {
+        return ""
+    }
+
+    return minAlfrescoVersion + ".99"
+}
+
+ext {
+    alfresco_50_min_version = "5.0"
+    alfresco_51_min_version = "5.1"
+    alfresco_52_min_version = "5.2"
+    alfresco_60_min_version = "6.0"
+    alfresco_61_min_version = "6.1"
+}
+
 subprojects {
     apply from: "${rootProject.projectDir}/publish.gradle"
     apply from: "${project.projectDir}/overrides.gradle"

--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -21,14 +21,6 @@ String getMaxRepositoryVersionRequirement(Project currentProject, String minAlfr
     return minAlfrescoVersion + ".99"
 }
 
-ext {
-    alfresco_50_min_version = "5.0"
-    alfresco_51_min_version = "5.1"
-    alfresco_52_min_version = "5.2"
-    alfresco_60_min_version = "6.0"
-    alfresco_61_min_version = "6.1"
-}
-
 subprojects {
     apply from: "${rootProject.projectDir}/publish.gradle"
     apply from: "${project.projectDir}/overrides.gradle"


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-416

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
