### PR TITLE
Extend NodeAssociations object to include peer-source associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint
+* [ALFREDAPI-420](https://xenitsupport.jira.com/browse/ALFREDAPI-420): Add missing Associations to getAssociations call
 
 ### Deleted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
 
 ### Changed
 * [ALFREDAPI-416](https://xenitsupport.jira.com/browse/ALFREDAPI-416): Removed max repository version from module.properties for builds for most recent Alfresco
+* [ALFREDAPI-420](https://xenitsupport.jira.com/browse/ALFREDAPI-420): Add missing Associations to getAssociations call; `getAssociations` now also returns source associations for a node. `/nodes/nodeInfo` will now also returns source associations by default.
 
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint
-* [ALFREDAPI-420](https://xenitsupport.jira.com/browse/ALFREDAPI-420): Add missing Associations to getAssociations call
 
 ### Deleted
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/metadata/NodeServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/metadata/NodeServiceTest.java
@@ -404,12 +404,14 @@ public class NodeServiceTest extends BaseTest {
                     ContentModel.ASSOC_CONTAINS,
                     (QName) null, true);
 
+            this.alfrescoNodeService.createAssociation(testNode.getNodeRef(), copyNodeRef, ContentModel.ASSOC_ORIGINAL);
+
             // Test for peerassociations as fetched from the source
-            List<NodeAssociation> peerAssociations = this.service.getTargetAssociations(c.apix(copyNodeRef));
+            List<NodeAssociation> peerAssociations = this.service.getTargetAssociations(c.apix(testNode.getNodeRef()));
             assertPeerAssociation(testNode.getNodeRef(), copyNodeRef, peerAssociations);
 
             // Test for peerassociations as fetched from the target
-            peerAssociations = this.service.getSourceAssociations(c.apix(testNode.getNodeRef()));
+            peerAssociations = this.service.getSourceAssociations(c.apix(copyNodeRef));
             assertPeerAssociation(testNode.getNodeRef(), copyNodeRef, peerAssociations);
 
         } finally {

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/metadata/NodeServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/metadata/NodeServiceTest.java
@@ -421,14 +421,13 @@ public class NodeServiceTest extends BaseTest {
 
     protected void assertPeerAssociation(NodeRef source, NodeRef target, List<NodeAssociation> peerAssociations) {
         assertEquals(peerAssociations.size(), 1);
-        for (NodeAssociation peerAssoc : peerAssociations) {
-            logger.debug(" Peer assoc source: " + peerAssoc.getSource().toString());
-            logger.debug(" Peer assoc target: " + peerAssoc.getTarget().toString());
-            logger.debug(" Peer assoc type: " + peerAssoc.getType().toString());
-            assertEquals(peerAssoc.getSource().toString(), source.toString());
-            assertEquals(peerAssoc.getTarget().toString(), target.toString());
-            assertEquals(peerAssoc.getType().toString(), ContentModel.ASSOC_ORIGINAL.toString());
-        }
+        NodeAssociation peerAssoc = peerAssociations.get(0);
+        logger.debug(" Peer assoc source: " + peerAssoc.getSource().toString());
+        logger.debug(" Peer assoc target: " + peerAssoc.getTarget().toString());
+        logger.debug(" Peer assoc type: " + peerAssoc.getType().toString());
+        assertEquals(peerAssoc.getSource().toString(), source.toString());
+        assertEquals(peerAssoc.getTarget().toString(), target.toString());
+        assertEquals(peerAssoc.getType().toString(), ContentModel.ASSOC_ORIGINAL.toString());
     }
 
     @Test

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/metadata/NodeServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/metadata/NodeServiceTest.java
@@ -404,18 +404,28 @@ public class NodeServiceTest extends BaseTest {
                     ContentModel.ASSOC_CONTAINS,
                     (QName) null, true);
 
+            // Test for peerassociations as fetched from the source
             List<NodeAssociation> peerAssociations = this.service.getTargetAssociations(c.apix(copyNodeRef));
-            assertEquals(peerAssociations.size(), 1);
-            for (NodeAssociation peerAssoc : peerAssociations) {
-                logger.debug(" Peer assoc source: " + peerAssoc.getSource().toString());
-                logger.debug(" Peer assoc target: " + peerAssoc.getTarget().toString());
-                logger.debug(" Peer assoc type: " + peerAssoc.getType().toString());
-                assertEquals(peerAssoc.getSource().toString(), copyNodeRef.toString());
-                assertEquals(peerAssoc.getTarget().toString(), testNode.getNodeRef().toString());
-                assertEquals(peerAssoc.getType().toString(), ContentModel.ASSOC_ORIGINAL.toString());
-            }
+            assertPeerAssociation(testNode.getNodeRef(), copyNodeRef, peerAssociations);
+
+            // Test for peerassociations as fetched from the target
+            peerAssociations = this.service.getSourceAssociations(c.apix(testNode.getNodeRef()));
+            assertPeerAssociation(testNode.getNodeRef(), copyNodeRef, peerAssociations);
+
         } finally {
             this.removeTestNode(mainTestFolder.getNodeRef());
+        }
+    }
+
+    protected void assertPeerAssociation(NodeRef source, NodeRef target, List<NodeAssociation> peerAssociations) {
+        assertEquals(peerAssociations.size(), 1);
+        for (NodeAssociation peerAssoc : peerAssociations) {
+            logger.debug(" Peer assoc source: " + peerAssoc.getSource().toString());
+            logger.debug(" Peer assoc target: " + peerAssoc.getTarget().toString());
+            logger.debug(" Peer assoc type: " + peerAssoc.getType().toString());
+            assertEquals(peerAssoc.getSource().toString(), source.toString());
+            assertEquals(peerAssoc.getTarget().toString(), target.toString());
+            assertEquals(peerAssoc.getType().toString(), ContentModel.ASSOC_ORIGINAL.toString());
         }
     }
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.model.Repository;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
@@ -419,8 +420,21 @@ public class NodeService implements INodeService {
     }
 
     @Override
+    public List<NodeAssociation> getSourceAssociations(eu.xenit.apix.data.NodeRef ref) {
+        return this.nodeService.getSourceAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL)
+                .stream()
+                .map(alfPeerAssoc ->
+                        new NodeAssociation(
+                            ref,
+                            c.apix(alfPeerAssoc.getSourceRef()),
+                            c.apix(alfPeerAssoc.getTypeQName())))
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public NodeAssociations getAssociations(eu.xenit.apix.data.NodeRef ref) {
-        return new NodeAssociations(getChildAssociations(ref), getParentAssociations(ref), getTargetAssociations(ref));
+        return new NodeAssociations(getChildAssociations(ref), getParentAssociations(ref), getTargetAssociations(ref),
+                getSourceAssociations(ref));
     }
 
     @Override

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -374,54 +374,45 @@ public class NodeService implements INodeService {
 
     @Override
     public List<ChildParentAssociation> getChildAssociations(eu.xenit.apix.data.NodeRef ref) {
-        List<ChildParentAssociation> apixChildAssocs = new ArrayList<>();
-        List<ChildAssociationRef> alfChildAssocs = this.nodeService.getChildAssocs(c.alfresco(ref));
-        for (ChildAssociationRef alfChildAssoc : alfChildAssocs) {
-            NodeRef alfChildRef = alfChildAssoc.getChildRef();
-            QName alfType = alfChildAssoc.getTypeQName();
-            boolean isPrimary = alfChildAssoc.isPrimary();
-            ChildParentAssociation apixChildAssoc = new ChildParentAssociation(ref, c.apix(alfChildRef),
-                    c.apix(alfType), isPrimary);
-            apixChildAssocs.add(apixChildAssoc);
-        }
-
-        return apixChildAssocs;
+        return nodeService.getChildAssocs(c.alfresco(ref))
+                .stream().map(alfChildAssoc ->
+                        new ChildParentAssociation(
+                                ref,
+                                c.apix(alfChildAssoc.getChildRef()),
+                                c.apix(alfChildAssoc.getTypeQName()),
+                                alfChildAssoc.isPrimary()
+                        ))
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<ChildParentAssociation> getParentAssociations(eu.xenit.apix.data.NodeRef ref) {
-        List<ChildParentAssociation> apixParentAssocs = new ArrayList<>();
-        List<ChildAssociationRef> alfParentAssocs = this.nodeService.getParentAssocs(c.alfresco(ref));
-        for (ChildAssociationRef alfParentAssoc : alfParentAssocs) {
-            NodeRef alfParentRef = alfParentAssoc.getParentRef();
-            QName alfType = alfParentAssoc.getTypeQName();
-            boolean isPrimary = alfParentAssoc.isPrimary();
-            ChildParentAssociation apixParentAssoc = new ChildParentAssociation(ref, c.apix(alfParentRef),
-                    c.apix(alfType), isPrimary);
-            apixParentAssocs.add(apixParentAssoc);
-        }
-
-        return apixParentAssocs;
+        return nodeService.getParentAssocs(c.alfresco(ref))
+                .stream().map(alfParentAssoc ->
+                        new ChildParentAssociation(
+                                c.apix(alfParentAssoc.getParentRef()),
+                                ref,
+                                c.apix(alfParentAssoc.getTypeQName()),
+                                alfParentAssoc.isPrimary()
+                        ))
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<NodeAssociation> getTargetAssociations(eu.xenit.apix.data.NodeRef ref) {
-        List<NodeAssociation> apixPeerAssocs = new ArrayList<>();
-        List<AssociationRef> alfPeerAssocs = this.nodeService
-                .getTargetAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL);
-        for (AssociationRef alfPeerAssoc : alfPeerAssocs) {
-            NodeRef alfPeerRef = alfPeerAssoc.getTargetRef();
-            QName alfType = alfPeerAssoc.getTypeQName();
-            NodeAssociation apixPeerAssoc = new NodeAssociation(ref, c.apix(alfPeerRef), c.apix(alfType));
-            apixPeerAssocs.add(apixPeerAssoc);
-        }
-
-        return apixPeerAssocs;
+        return nodeService.getTargetAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL)
+                .stream()
+                .map(alfPeerAssoc ->
+                        new NodeAssociation(
+                                ref,
+                                c.apix(alfPeerAssoc.getTargetRef()),
+                                c.apix(alfPeerAssoc.getTypeQName())))
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<NodeAssociation> getSourceAssociations(eu.xenit.apix.data.NodeRef ref) {
-        return this.nodeService.getSourceAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL)
+        return nodeService.getSourceAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL)
                 .stream()
                 .map(alfPeerAssoc ->
                         new NodeAssociation(

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -390,8 +390,8 @@ public class NodeService implements INodeService {
         return nodeService.getParentAssocs(c.alfresco(ref))
                 .stream().map(alfParentAssoc ->
                         new ChildParentAssociation(
-                                c.apix(alfParentAssoc.getParentRef()),
                                 ref,
+                                c.apix(alfParentAssoc.getParentRef()),
                                 c.apix(alfParentAssoc.getTypeQName()),
                                 alfParentAssoc.isPrimary()
                         ))

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -425,8 +425,8 @@ public class NodeService implements INodeService {
                 .stream()
                 .map(alfPeerAssoc ->
                         new NodeAssociation(
-                            ref,
                             c.apix(alfPeerAssoc.getSourceRef()),
+                            ref,
                             c.apix(alfPeerAssoc.getTypeQName())))
                 .collect(Collectors.toList());
     }

--- a/apix-interface/src/main/java/eu/xenit/apix/node/INodeService.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/node/INodeService.java
@@ -57,10 +57,18 @@ public interface INodeService {
     /**
      * Fetches all associations for which the given node is the source.
      *
-     * @param ref The node for which the target associations are requested.
-     * @return The parent associations of the given node.
+     * @param ref The node for which the associations are requested.
+     * @return The peer associations of the given node for which it is the source
      */
     List<NodeAssociation> getTargetAssociations(NodeRef ref);
+
+    /**
+     * Fetches all associations for which the given node is the target.
+     *
+     * @param ref The node for which the associations are requested.
+     * @return The peer associations of the given node for which it is the target
+     */
+    List<NodeAssociation> getSourceAssociations(NodeRef ref);
 
     /**
      * Returns all target, parent and child associations of the given node.

--- a/apix-interface/src/main/java/eu/xenit/apix/node/NodeAssociations.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/node/NodeAssociations.java
@@ -10,15 +10,17 @@ public class NodeAssociations {
     private List<ChildParentAssociation> children;
     private List<ChildParentAssociation> parents;
     private List<NodeAssociation> targets;
+    private List<NodeAssociation> sources;
 
     public NodeAssociations() {
     }
 
     public NodeAssociations(List<ChildParentAssociation> children, List<ChildParentAssociation> parents,
-            List<NodeAssociation> targets) {
+            List<NodeAssociation> targets, List<NodeAssociation> sources) {
         this.children = children;
         this.parents = parents;
         this.targets = targets;
+        this.sources = sources;
     }
 
     public List<ChildParentAssociation> getChildren() {
@@ -43,5 +45,13 @@ public class NodeAssociations {
 
     public void setTargets(List<NodeAssociation> targets) {
         this.targets = targets;
+    }
+
+    public List<NodeAssociation> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<NodeAssociation> sources) {
+        this.sources = sources;
     }
 }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/ApixV1Webscript.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/ApixV1Webscript.java
@@ -62,12 +62,14 @@ public class ApixV1Webscript {
             boolean retrieveAssocs,
             boolean retrieveChildAssocs,
             boolean retrieveParentAssocs,
-            boolean retrieveTargetAssocs) {
+            boolean retrieveTargetAssocs,
+            boolean retrieveSourceAssocs
+    ) {
         List<NodeInfo> nodeInfoList = new ArrayList<>();
         for (NodeRef nodeRef : nodeRefs) {
             NodeInfo nodeInfo = nodeRefToNodeInfo(nodeRef, fileFolderService, nodeService, permissionService,
                     retrievePath, retrieveMetadata, retrievePermissions, retrieveAssocs, retrieveChildAssocs,
-                    retrieveParentAssocs, retrieveTargetAssocs);
+                    retrieveParentAssocs, retrieveTargetAssocs, retrieveSourceAssocs);
             if (nodeInfo == null) {
                 continue;
             }
@@ -82,7 +84,7 @@ public class ApixV1Webscript {
             INodeService nodeService, IPermissionService permissionService) {
         return nodeRefToNodeInfo(nodeRef, fileFolderService, nodeService, permissionService,
                 true, true, true, true,
-                true, true, true);
+                true, true, true, true);
     }
 
     protected NodeInfo nodeRefToNodeInfo(NodeRef nodeRef,
@@ -95,7 +97,8 @@ public class ApixV1Webscript {
             boolean retrieveAssocs,
             boolean retrieveChildAssocs,
             boolean retrieveParentAssocs,
-            boolean retrieveTargetAssocs) {
+            boolean retrieveTargetAssocs,
+            boolean retrieveSourceAssocs) {
         if (!permissionService.hasPermission(nodeRef, IPermissionService.READ)) {
             logger.warn("Excluding node {} from results due to insufficient permissions", nodeRef);
             return null;
@@ -130,7 +133,12 @@ public class ApixV1Webscript {
             if (retrieveTargetAssocs) {
                 targetAssociations = nodeService.getTargetAssociations(nodeRef);
             }
-            associations = new NodeAssociations(childAssocs, parentAssociations, targetAssociations);
+            List<NodeAssociation> sourceAssociationts = null;
+            if (retrieveSourceAssocs) {
+                sourceAssociationts = nodeService.getSourceAssociations(nodeRef);
+            }
+            associations = new NodeAssociations(childAssocs, parentAssociations, targetAssociations,
+                    sourceAssociationts);
         }
 
         return new NodeInfo(nodeRef, nodeMetadata, permissions, associations, path);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -406,7 +406,8 @@ public class NodesWebscript1 extends ApixV1Webscript {
                     +
                     "Set 'retrieveChildAssocs' to false to omit the child associations from the result.\n" +
                     "Set 'retrieveParentAssocs' to false to omit the parent associations from the result.\n" +
-                    "Set 'retrieveTargetAssocs' to false to omit the peer associations from the result.\n")
+                    "Set 'retrieveTargetAssocs' to false to omit the peer target associations from the result.\n" +
+                    "Set 'retrieveSourceAssocs' to false to omit the peer source associations from the result.\n")
     @Uri(value = "/nodes/nodeInfo", method = HttpMethod.POST)
     @ApiResponses(@ApiResponse(code = 200, message = "Success", response = NodeInfo[].class))
     public void getAllInfoOfNodes(WebScriptRequest request, WebScriptResponse response)
@@ -426,6 +427,7 @@ public class NodesWebscript1 extends ApixV1Webscript {
         boolean retrieveChildAssocs = true;
         boolean retrieveParentAssocs = true;
         boolean retrieveTargetAssocs = true;
+        boolean retrieveSourceAssocs = true;
 
         List<NodeRef> nodeRefs = new ArrayList<NodeRef>();
         try {
@@ -449,6 +451,9 @@ public class NodesWebscript1 extends ApixV1Webscript {
             }
             if (jsonObject.has("retrieveTargetAssocs")) {
                 retrieveTargetAssocs = jsonObject.getBoolean("retrieveTargetAssocs");
+            }
+            if (jsonObject.has("retrieveSourceAssocs")) {
+                retrieveSourceAssocs = jsonObject.getBoolean("retrieveSourceAssocs");
             }
 
             JSONArray nodeRefsJsonArray = jsonObject.getJSONArray("noderefs");
@@ -481,7 +486,8 @@ public class NodesWebscript1 extends ApixV1Webscript {
                 retrieveAssocs,
                 retrieveChildAssocs,
                 retrieveParentAssocs,
-                retrieveTargetAssocs);
+                retrieveTargetAssocs,
+                retrieveSourceAssocs);
         //logger.error("end nodeRefToNodeInfo");
 
         //logger.error("start writeJsonResponse");

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/sites/SitesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/sites/SitesWebscript1.java
@@ -63,7 +63,8 @@ public class SitesWebscript1 extends ApixV1Webscript {
                     + "Set 'retrievePermissions' to true to return the permissions of the sites.\n"
                     + "Set 'retrieveChildAssocs' to true to return the child associations of the sites.\n"
                     + "Set 'retrieveParentAssocs' to true to return the parent associations of the sites.\n"
-                    + "Set 'retrieveTargetAssocs' to true to return the peer associations of the sites.\n")
+                    + "Set 'retrieveTargetAssocs' to true to return the target peer associations of the sites.\n"
+                    + "Set 'retrieveSourceAssocs' to true to return the source peer associations of the sites.\n")
     @Uri(value = "/sites/mySites", method = HttpMethod.GET)
     @ApiResponses(@ApiResponse(code = 200, message = "Success", response = SiteInfo[].class))
     public void getMySites(@RequestParam(required = false, defaultValue = "false") Boolean retrieveMetadata,
@@ -72,6 +73,7 @@ public class SitesWebscript1 extends ApixV1Webscript {
             @RequestParam(required = false, defaultValue = "false") boolean retrieveChildAssocs,
             @RequestParam(required = false, defaultValue = "false") boolean retrieveParentAssocs,
             @RequestParam(required = false, defaultValue = "false") boolean retrieveTargetAssocs,
+            @RequestParam(required = false, defaultValue = "false") boolean retrieveSourceAssocs,
             WebScriptResponse response)
             throws IOException {
         logger.debug("retrieveMetadata: " + retrieveMetadata);
@@ -80,6 +82,7 @@ public class SitesWebscript1 extends ApixV1Webscript {
         logger.debug("retrieveChildAssocs: " + retrieveChildAssocs);
         logger.debug("retrieveParentAssocs: " + retrieveParentAssocs);
         logger.debug("retrieveTargetAssocs: " + retrieveTargetAssocs);
+        logger.debug("retrieveSourceAssocs: " + retrieveSourceAssocs);
 
         AuthenticationService authService = serviceRegistry.getAuthenticationService();
         List<ISite> sites = siteService.getUserSites(authService.getCurrentUserName());
@@ -88,7 +91,7 @@ public class SitesWebscript1 extends ApixV1Webscript {
             NodeRef siteRef = site.getNodeRef();
             NodeInfo nodeInfo = nodeRefToNodeInfo(siteRef, fileFolderService, nodeService, permissionService,
                     retrievePath, retrieveMetadata, retrievePermissions, true, retrieveChildAssocs,
-                    retrieveParentAssocs, retrieveTargetAssocs);
+                    retrieveParentAssocs, retrieveTargetAssocs, retrieveSourceAssocs);
             SiteInfo siteInfo = new SiteInfo(site, nodeInfo);
             siteInfoList.add(siteInfo);
         }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/ApixV2Webscript.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/ApixV2Webscript.java
@@ -41,7 +41,7 @@ public class ApixV2Webscript extends ApixV1Webscript {
             boolean retrievePath, boolean retrieveMetadata,
             boolean retrievePermissions, boolean retrieveAssocs,
             boolean retrieveChildAssocs, boolean retrieveParentAssocs,
-            boolean retrieveTargetAssocs) {
+            boolean retrieveTargetAssocs, boolean retrieveSourceAssocs) {
         List<NodeInfo> nodeInfoList = new ArrayList<NodeInfo>();
         for (NodeRef nodeRef : nodeRefs) {
             logger.debug("######################################################");
@@ -82,7 +82,11 @@ public class ApixV2Webscript extends ApixV1Webscript {
                 if (retrieveTargetAssocs) {
                     targetAssociations = nodeService.getTargetAssociations(nodeRef);
                 }
-                associations = new NodeAssociations(childAssocs, parentAssociations, targetAssociations);
+                List<NodeAssociation> sourceAssociations = null;
+                if (retrieveSourceAssocs) {
+                    targetAssociations = nodeService.getSourceAssociations(nodeRef);
+                }
+                associations = new NodeAssociations(childAssocs, parentAssociations, targetAssociations, sourceAssociations);
             }
             logger.debug("end getAssociations");
 

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
@@ -102,7 +102,8 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
                     +
                     "Set 'retrieveChildAssocs' to false to omit the child associations from the result.\n" +
                     "Set 'retrieveParentAssocs' to false to omit the parent associations from the result.\n" +
-                    "Set 'retrieveTargetAssocs' to false to omit the peer associations from the result.\n")
+                    "Set 'retrieveTargetAssocs' to false to omit the peer target associations from the result.\n" +
+                    "Set 'retrieveSourceAssocs' to false to omit the peer source associations from the result.\n")
     @Uri(value = "/nodes/nodeInfo", method = HttpMethod.POST)
     @ApiResponses(@ApiResponse(code = 200, message = "Success", response = NodeInfo[].class))
     public void getAllInfos(WebScriptRequest request, WebScriptResponse response) throws IOException, JSONException {
@@ -122,6 +123,7 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
         boolean retrieveChildAssocs = true;
         boolean retrieveParentAssocs = true;
         boolean retrieveTargetAssocs = true;
+        boolean retrieveSourceAssocs = true;
 
         List<NodeRef> nodeRefs = new ArrayList<NodeRef>();
         try {
@@ -145,6 +147,9 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
             }
             if (jsonObject.has("retrieveTargetAssocs")) {
                 retrieveTargetAssocs = jsonObject.getBoolean("retrieveTargetAssocs");
+            }
+            if (jsonObject.has("retrieveSourceAssocs")) {
+                retrieveSourceAssocs = jsonObject.getBoolean("retrieveSourceAssocs");
             }
 
             JSONArray nodeRefsJsonArray = jsonObject.getJSONArray("noderefs");
@@ -178,7 +183,8 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
                 retrieveAssocs,
                 retrieveChildAssocs,
                 retrieveParentAssocs,
-                retrieveTargetAssocs);
+                retrieveTargetAssocs,
+                retrieveSourceAssocs);
         logger.debug("end nodeRefToNodeInfo");
 
         logger.debug("start writeJsonResponse");


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-420

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
