### PR TITLE
Alfredapi 421 Add 403 Not Authorized responses to NodesWebscript1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 * [ALFREDAPI-416](https://xenitsupport.jira.com/browse/ALFREDAPI-416): Removed max repository version from module.properties for builds for most recent Alfresco
 * [ALFREDAPI-420](https://xenitsupport.jira.com/browse/ALFREDAPI-420): Add missing Associations to getAssociations call; `getAssociations` now also returns source associations for a node. `/nodes/nodeInfo` will now also returns source associations by default.
+* [ALFREDAPI-421](https://xenitsupport.jira.com/browse/ALFREDAPI-421): Add 403 Not Authorized responses to `NodesWebscript1.java`
 
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -17,6 +17,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import eu.xenit.apix.data.NodeRef;
 import java.io.IOException;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
@@ -36,8 +37,8 @@ public class AllNodeInfoTest extends BaseTest {
 
     @Test
     public void testGetAllNodeInfo() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "admin", "admin");
         logger.info(" URL: " + url);
         for (int i = 0; i < 20; i++) {
             logger.error("For the request of testGetAllNodeInfo");
@@ -52,9 +53,9 @@ public class AllNodeInfoTest extends BaseTest {
 
     @Test
     public void testGetAllNodeInfoOfMultipleNodes() throws IOException, JSONException {
-        NodeRef[] nodeRefs = init();
-        NodeRef nodeRef0 = nodeRefs[0];
-        NodeRef nodeRef1 = nodeRefs[1];
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        NodeRef nodeRef0 = initializedNodeRefs.get(BaseTest.TESTFILE_NAME);
+        NodeRef nodeRef1 = initializedNodeRefs.get(BaseTest.TESTFILE2_NAME);
 
         String jsonString = json(String.format(
                 "{" +

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AssociationsTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AssociationsTest.java
@@ -56,6 +56,14 @@ public class AssociationsTest extends BaseTest {
     }
 
     @Test
+    public void testAssociationsGetDenied() throws IOException {
+        NodeRef[] initArray = init();
+        String url = makeNodesUrl(initArray[3], "/associations", "red", "red");
+        HttpResponse response = Request.Get(url).execute().returnResponse();
+        assertEquals(403, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
     public void testParentAssociationsGet() throws IOException {
         NodeRef[] nodeRef = init();
         String url = makeNodesUrl(nodeRef[0], "/associations/parents", "admin", "admin");

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AssociationsTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AssociationsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
 import eu.xenit.apix.data.NodeRef;
 import java.io.IOException;
+import java.util.HashMap;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
@@ -47,8 +48,8 @@ public class AssociationsTest extends BaseTest {
 
     @Test
     public void testAssociationsGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/associations", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/associations", "admin", "admin");
 
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
@@ -57,16 +58,18 @@ public class AssociationsTest extends BaseTest {
 
     @Test
     public void testAssociationsGetDenied() throws IOException {
-        NodeRef[] initArray = init();
-        String url = makeNodesUrl(initArray[3], "/associations", "red", "red");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/associations", BaseTest.USERWITHOUTRIGHTS,
+                BaseTest.USERWITHOUTRIGHTS);
         HttpResponse response = Request.Get(url).execute().returnResponse();
         assertEquals(403, response.getStatusLine().getStatusCode());
     }
 
     @Test
     public void testParentAssociationsGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/associations/parents", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/associations/parents", "admin",
+                "admin");
 
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
@@ -75,8 +78,9 @@ public class AssociationsTest extends BaseTest {
 
     @Test
     public void testChildAssociationsGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/associations/children", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/associations/children", "admin",
+                "admin");
 
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
@@ -85,8 +89,9 @@ public class AssociationsTest extends BaseTest {
 
     @Test
     public void testPeerAssociationsGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/associations/targets", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/associations/targets", "admin",
+                "admin");
 
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
@@ -95,9 +100,9 @@ public class AssociationsTest extends BaseTest {
 
     @Test
     public void testCreateAssociation() throws IOException {
-        NodeRef[] nodes = init();
-        final NodeRef nodeRefA = nodes[0];
-        final NodeRef nodeRefB = nodes[1];
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        final NodeRef nodeRefA = initializedNodeRefs.get(BaseTest.TESTFILE_NAME);
+        final NodeRef nodeRefB = initializedNodeRefs.get(BaseTest.TESTFILE2_NAME);
 
         final java.util.List<org.alfresco.service.cmr.repository.AssociationRef> assocs = nodeService
                 .getTargetAssocs(c.alfresco(nodeRefA), RegexQNamePattern.MATCH_ALL);
@@ -130,9 +135,9 @@ public class AssociationsTest extends BaseTest {
 
     @Test
     public void testRemoveAssociation() throws IOException {
-        NodeRef[] nodes = init();
-        final NodeRef nodeRefA = nodes[0];
-        final NodeRef nodeRefB = nodes[1];
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        final NodeRef nodeRefA = initializedNodeRefs.get(BaseTest.TESTFILE_NAME);
+        final NodeRef nodeRefB = initializedNodeRefs.get(BaseTest.TESTFILE2_NAME);
 
         serviceRegistry.getRetryingTransactionHelper()
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/BaseTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/BaseTest.java
@@ -54,6 +54,19 @@ public abstract class BaseTest {
     private final static Logger logger = LoggerFactory.getLogger(BaseTest.class);
     private final static String VERSION = "v1";
 
+    public static final String MAIN_TESTFOLDER_NAME = "mainTestFolder";
+    public static final String TESTFOLDER_NAME = "testFolder";
+    public static final String TESTFILE_NAME = "testFile";
+    public static final String TESTFOLDER2_NAME = "testFolder2";
+    public static final String TESTFILE2_NAME = "testFile2";
+    public static final String TESTFILE3_NAME = "testFile3";
+    public static final String NOUSERRIGHTS_FOLDER_NAME = "noUserRightsTestFolder";
+    public static final String NOUSERRIGHTS_FILE_NAME = "noUserRightsTestFile";
+
+    public static final String USERWITHOUTRIGHTS = "red";
+    public static final String USERWITHOUTRIGHTS_EMAIL =
+            USERWITHOUTRIGHTS + "@" + USERWITHOUTRIGHTS + ".com";
+
     @Autowired
     protected ServiceRegistry serviceRegistry;
 
@@ -172,8 +185,8 @@ public abstract class BaseTest {
         return String.format(makeAlfrescoBaseurl() + "/apix/" + getVersion() + "/bulk?alf_ticket=" + ticket);
     }
 
-    protected eu.xenit.apix.data.NodeRef[] init() {
-        final eu.xenit.apix.data.NodeRef[] ref = {null, null, null, null};
+    protected HashMap<String, eu.xenit.apix.data.NodeRef> init() {
+        final HashMap<String, eu.xenit.apix.data.NodeRef> initializedNodeRefs = new HashMap<>();
         TransactionService transactionService = serviceRegistry.getTransactionService();
 
         this.removeMainTestFolder();
@@ -181,45 +194,48 @@ public abstract class BaseTest {
         RetryingTransactionHelper.RetryingTransactionCallback<Object> txnWork = new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
             public Object execute() throws Exception {
                 NodeRef companyHomeRef = repository.getCompanyHome();
-                FileInfo mainTestFolder = createTestNode(companyHomeRef, "mainTestFolder", ContentModel.TYPE_FOLDER);
-                FileInfo testFolder = createTestNode(mainTestFolder.getNodeRef(), "testFolder",
+                FileInfo mainTestFolder = createTestNode(companyHomeRef, MAIN_TESTFOLDER_NAME,
                         ContentModel.TYPE_FOLDER);
-                FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testFile", ContentModel.TYPE_CONTENT);
+                FileInfo testFolder = createTestNode(mainTestFolder.getNodeRef(), TESTFOLDER_NAME,
+                        ContentModel.TYPE_FOLDER);
+                FileInfo testNode = createTestNode(testFolder.getNodeRef(), TESTFILE_NAME, ContentModel.TYPE_CONTENT);
                 NodeRef testNodeRef = testNode.getNodeRef();
                 eu.xenit.apix.data.NodeRef apixTestNodeRef = new eu.xenit.apix.data.NodeRef(testNodeRef.toString());
-                ref[0] = apixTestNodeRef;
+                initializedNodeRefs.put(TESTFILE_NAME, apixTestNodeRef);
 
-                FileInfo testFolder2 = createTestNode(mainTestFolder.getNodeRef(), "testFolder2",
+                FileInfo testFolder2 = createTestNode(mainTestFolder.getNodeRef(), TESTFOLDER2_NAME,
                         ContentModel.TYPE_FOLDER);
-                FileInfo testNode2 = createTestNode(testFolder2.getNodeRef(), "testFile2", ContentModel.TYPE_CONTENT);
+                FileInfo testNode2 = createTestNode(testFolder2.getNodeRef(), TESTFILE2_NAME,
+                        ContentModel.TYPE_CONTENT);
                 NodeRef testNodeRef2 = testNode2.getNodeRef();
                 eu.xenit.apix.data.NodeRef apixTestNodeRef2 = new eu.xenit.apix.data.NodeRef(testNodeRef2.toString());
-                ref[1] = apixTestNodeRef2;
+                initializedNodeRefs.put(TESTFILE2_NAME, apixTestNodeRef2);
 
-                FileInfo testNode3 = createTestNode(testFolder2.getNodeRef(), "testFile3", ContentModel.TYPE_CONTENT);
+                FileInfo testNode3 = createTestNode(testFolder2.getNodeRef(), TESTFILE3_NAME,
+                        ContentModel.TYPE_CONTENT);
                 NodeRef testNodeRef3 = testNode3.getNodeRef();
                 eu.xenit.apix.data.NodeRef apixTestNodeRef3 = new eu.xenit.apix.data.NodeRef(testNodeRef3.toString());
-                ref[2] = apixTestNodeRef3;
+                initializedNodeRefs.put(TESTFILE3_NAME, apixTestNodeRef3);
 
-                FileInfo noUserRightsFolder = createTestNode(mainTestFolder.getNodeRef(), "noUserRightsTestFolder",
+                FileInfo noUserRightsFolder = createTestNode(mainTestFolder.getNodeRef(), NOUSERRIGHTS_FOLDER_NAME,
                         ContentModel.TYPE_FOLDER);
                 setPermissionInheritance(noUserRightsFolder.getNodeRef(), false);
-                FileInfo noUserRightsNode = createTestNode(noUserRightsFolder.getNodeRef(), "noUserRightsTestFile",
+                FileInfo noUserRightsNode = createTestNode(noUserRightsFolder.getNodeRef(), NOUSERRIGHTS_FILE_NAME,
                         ContentModel.TYPE_CONTENT);
                 NodeRef noUserRightsNodeRef = noUserRightsNode.getNodeRef();
                 setPermissionInheritance(noUserRightsNodeRef, false);
                 eu.xenit.apix.data.NodeRef apixNoUserRightsNodeRef = new eu.xenit.apix.data.NodeRef(
                         noUserRightsNodeRef.toString());
-                ref[3] = apixNoUserRightsNodeRef;
+                initializedNodeRefs.put(NOUSERRIGHTS_FILE_NAME, apixNoUserRightsNodeRef);
 
-                String red = "red";
-                createUser(red, red, red, (red+"@"+red+".com"));
+                createUser(USERWITHOUTRIGHTS, USERWITHOUTRIGHTS, USERWITHOUTRIGHTS,
+                        USERWITHOUTRIGHTS_EMAIL);
                 return null;
             }
         };
 
         transactionService.getRetryingTransactionHelper().doInTransaction(txnWork, false, true);
-        return ref;
+        return initializedNodeRefs;
     }
 
     protected String makeNodesUrl(eu.xenit.apix.data.NodeRef nodeRef, String userName, String passWord) {
@@ -260,7 +276,7 @@ public abstract class BaseTest {
 
     protected NodeRef getMainTestFolder() {
         FileFolderService fileFolderService = this.serviceRegistry.getFileFolderService();
-        NodeRef nodeRef = fileFolderService.searchSimple(repository.getCompanyHome(), "mainTestFolder");
+        NodeRef nodeRef = fileFolderService.searchSimple(repository.getCompanyHome(), MAIN_TESTFOLDER_NAME);
         return nodeRef;
     }
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/BulkTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/BulkTest.java
@@ -1,13 +1,15 @@
 package eu.xenit.apix.rest.v1.tests;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.node.ChildParentAssociation;
 import eu.xenit.apix.node.INodeService;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
@@ -21,6 +23,8 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -58,8 +62,9 @@ public class BulkTest extends BaseTest {
 
     @Test
     public void testGetBulk() throws IOException, JSONException {
-        NodeRef[] nodeRef = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[0]);
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService
+                .getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssoc = parentAssociations.get(0);
         assertTrue(primaryParentAssoc.isPrimary());
         NodeRef parentRef = primaryParentAssoc.getTarget();
@@ -69,11 +74,12 @@ public class BulkTest extends BaseTest {
         CloseableHttpClient httpclient = HttpClients.createDefault();
         HttpPost httpPost = new HttpPost(url);
 
-        String firstGetUrl = removePrefixAndAuthenticate(makeNodesUrl(nodeRef[0], "/metadata", "admin", "admin"));
+        String firstGetUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/metadata", "admin", "admin"));
         String secondGetUrl = removePrefixAndAuthenticate(makeNodesUrl(parentRef, "/metadata", "admin", "admin"));
         httpPost.setEntity(new StringEntity(json(String
-              .format("[{'url':'%s','method':'%s'},{'url':'%s','method':'%s'}]", firstGetUrl, "get", secondGetUrl,
-                    "get"))));
+                .format("[{'url':'%s','method':'%s'},{'url':'%s','method':'%s'}]", firstGetUrl, "get", secondGetUrl,
+                        "get"))));
         try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
             String result = EntityUtils.toString(response.getEntity());
             logger.info(" Result bulk metadata get: " + result);
@@ -92,8 +98,9 @@ public class BulkTest extends BaseTest {
 
     @Test
     public void testUrlEncode() throws IOException, JSONException {
-        NodeRef[] nodeRef = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[0]);
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService
+                .getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssoc = parentAssociations.get(0);
         assertTrue(primaryParentAssoc.isPrimary());
         NodeRef parentRef = primaryParentAssoc.getTarget();
@@ -107,8 +114,8 @@ public class BulkTest extends BaseTest {
         String thirdGetUrl = "/properties/%7Bhttp%3A%2F%2Fwww.alfresco.org%2Fmodel%2Fcontent%2F1.0%7Dname";
 
         httpPost.setEntity(new StringEntity(json(String.format(
-              "[{'url':'%s','method':'get'},{'url':'%s','method':'get'},{'url':'%s','method':'get'}]",
-              firstGetUrl, secondGetUrl, thirdGetUrl))));
+                "[{'url':'%s','method':'get'},{'url':'%s','method':'get'},{'url':'%s','method':'get'}]",
+                firstGetUrl, secondGetUrl, thirdGetUrl))));
         try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
             String result = EntityUtils.toString(response.getEntity());
             logger.info(" Result bulk metadata get: " + result);
@@ -137,8 +144,9 @@ public class BulkTest extends BaseTest {
 
     @Test
     public void testPostBulk() throws IOException {
-        final NodeRef[] nodeRef = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[0]);
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService
+                .getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
         assertTrue(primaryParentAssoc.isPrimary());
         final NodeRef parentRef = primaryParentAssoc.getTarget();
@@ -147,103 +155,109 @@ public class BulkTest extends BaseTest {
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpPost httpPost = new HttpPost(url);
-        String firstPostUrl = removePrefixAndAuthenticate(makeNodesUrl(nodeRef[0], "/metadata", "admin", "admin"));
+        String firstPostUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/metadata", "admin", "admin"));
         String secondPostUrl = removePrefixAndAuthenticate(makeNodesUrl(parentRef, "/metadata", "admin", "admin"));
         String firstJsonBody = String.format("{'aspectsToAdd':['%s']}", ContentModel.ASPECT_VERSIONABLE.toString());
         String secondJsonBody = String.format("{'aspectsToAdd':['%s']}", ContentModel.ASPECT_VERSIONABLE.toString());
         String jsonString = json(
-              String.format("[{'url':'%s','method':'%s','body':%s},{'url':'%s','method':'%s','body':%s}]",
-                    firstPostUrl, "post", firstJsonBody,
-                    secondPostUrl, "post", secondJsonBody));
+                String.format("[{'url':'%s','method':'%s','body':%s},{'url':'%s','method':'%s','body':%s}]",
+                        firstPostUrl, "post", firstJsonBody,
+                        secondPostUrl, "post", secondJsonBody));
         httpPost.setEntity(new StringEntity(jsonString));
 
         transactionService.getRetryingTransactionHelper()
-              .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                  @Override
-                  public Object execute() throws Throwable {
-                      try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
-                          String result = EntityUtils.toString(response.getEntity());
-                          logger.info(" Result bulk metadata post: " + result);
-                          assertEquals(200, response.getStatusLine().getStatusCode());
-                          assertTrue(alfrescoNodeService
-                                .hasAspect(new org.alfresco.service.cmr.repository.NodeRef(nodeRef[0].getValue()),
-                                      ContentModel.ASPECT_VERSIONABLE));
-                          assertTrue(alfrescoNodeService
-                                .hasAspect(new org.alfresco.service.cmr.repository.NodeRef(parentRef.getValue()),
-                                      ContentModel.ASPECT_VERSIONABLE));
-                      }
-                      return null;
-                  }
-              }, false, true);
+                .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
+                    @Override
+                    public Object execute() throws Throwable {
+                        try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+                            String result = EntityUtils.toString(response.getEntity());
+                            logger.info(" Result bulk metadata post: " + result);
+                            assertEquals(200, response.getStatusLine().getStatusCode());
+                            assertTrue(alfrescoNodeService
+                                    .hasAspect(new org.alfresco.service.cmr.repository.NodeRef(
+                                                    initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()),
+                                            ContentModel.ASPECT_VERSIONABLE));
+                            assertTrue(alfrescoNodeService
+                                    .hasAspect(new org.alfresco.service.cmr.repository.NodeRef(parentRef.getValue()),
+                                            ContentModel.ASPECT_VERSIONABLE));
+                        }
+                        return null;
+                    }
+                }, false, true);
 
-        firstPostUrl = removePrefixAndAuthenticate(makeNodesUrl(nodeRef[1], "/metadata", "admin", "admin"));
-        secondPostUrl = removePrefixAndAuthenticate(makeNodesUrl(nodeRef[2], "/metadata", "admin", "admin"));
+        firstPostUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE2_NAME), "/metadata", "admin", "admin"));
+        secondPostUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE2_NAME), "/metadata", "admin", "admin"));
 
         firstJsonBody = String.format("{'propertiesToSet':{'%s':['newName']}}", ContentModel.PROP_NAME.toString());
         jsonString = json(String.format("[{'url':'%s','method':'%s','body':%s}]",
-              firstPostUrl, "post", firstJsonBody));
+                firstPostUrl, "post", firstJsonBody));
         final HttpPost httpPost2 = new HttpPost(url);
         httpPost2.setEntity(new StringEntity(jsonString));
         transactionService.getRetryingTransactionHelper()
-              .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                  @Override
-                  public Object execute() throws Throwable {
-                      try (CloseableHttpResponse response = httpclient.execute(httpPost2)) {
-                          String result = EntityUtils.toString(response.getEntity());
-                          logger.info(" Result bulk metadata post: " + result);
-                          assertEquals(200, response.getStatusLine().getStatusCode());
-                          assertEquals("newName", alfrescoNodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRef[1].getValue()),
-                                      ContentModel.PROP_NAME));
-                      }
-                      return null;
-                  }
-              }, false, true);
+                .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
+                    @Override
+                    public Object execute() throws Throwable {
+                        try (CloseableHttpResponse response = httpclient.execute(httpPost2)) {
+                            String result = EntityUtils.toString(response.getEntity());
+                            logger.info(" Result bulk metadata post: " + result);
+                            assertEquals(200, response.getStatusLine().getStatusCode());
+                            assertEquals("newName", alfrescoNodeService
+                                    .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                    initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue()),
+                                            ContentModel.PROP_NAME));
+                        }
+                        return null;
+                    }
+                }, false, true);
 
         secondJsonBody = String.format("{'propertiesToSet':{'%s':['newName']}}", ContentModel.PROP_NAME.toString());
         jsonString = json(String.format("[{'url':'%s','method':'%s','body':%s}]",
-              secondPostUrl, "post", secondJsonBody));
+                secondPostUrl, "post", secondJsonBody));
         final HttpPost httpPost3 = new HttpPost(url);
         httpPost3.setEntity(new StringEntity(jsonString));
         transactionService.getRetryingTransactionHelper()
-              .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                  @Override
-                  public Object execute() throws Throwable {
-                      try (CloseableHttpResponse response = httpclient.execute(httpPost3)) {
-                          String result = EntityUtils.toString(response.getEntity());
-                          logger.info(" Result bulk metadata post: " + result);
-                          assertEquals(200, response.getStatusLine().getStatusCode());
-                          assertNotEquals("newName", alfrescoNodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRef[2].getValue()),
-                                      ContentModel.PROP_NAME));
-                      }
-                      return null;
-                  }
-              }, false, true);
+                .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
+                    @Override
+                    public Object execute() throws Throwable {
+                        try (CloseableHttpResponse response = httpclient.execute(httpPost3)) {
+                            String result = EntityUtils.toString(response.getEntity());
+                            logger.info(" Result bulk metadata post: " + result);
+                            assertEquals(200, response.getStatusLine().getStatusCode());
+                            assertNotEquals("newName", alfrescoNodeService
+                                    .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                    initializedNodeRefs.get(BaseTest.TESTFILE3_NAME).getValue()),
+                                            ContentModel.PROP_NAME));
+                        }
+                        return null;
+                    }
+                }, false, true);
 
     }
 
     @Test
     public void testSubError() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
         final String firstUrlForRename = removePrefixAndAuthenticate(
-              makeNodesUrl(nodeRef[0], "/metadata", "admin", "admin"));
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/metadata", "admin", "admin"));
         final String secondUrlForError = removePrefixAndAuthenticate(
-              makeNodesUrl("c03be21a-ebfc-4486-a98a-0d3cae2c40ca", "/metadata", "admin", "admin"));
+                makeNodesUrl("c03be21a-ebfc-4486-a98a-0d3cae2c40ca", "/metadata", "admin", "admin"));
         final String thirdUrlForRename = removePrefixAndAuthenticate(
-              makeNodesUrl(nodeRef[1], "/metadata", "admin", "admin"));
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE2_NAME), "/metadata", "admin", "admin"));
         final String firstPostBody = String
-              .format("{'propertiesToSet':{'%s':['testName1']}}", ContentModel.PROP_NAME.toString());
+                .format("{'propertiesToSet':{'%s':['testName1']}}", ContentModel.PROP_NAME.toString());
         final String secndPostBody = String
-              .format("{'propertiesToSet':{'%s':['testName2']}}", ContentModel.PROP_NAME.toString());
+                .format("{'propertiesToSet':{'%s':['testName2']}}", ContentModel.PROP_NAME.toString());
         final String thirdPostBody = String
-              .format("{'propertiesToSet':{'%s':['testName3']}}", ContentModel.PROP_NAME.toString());
+                .format("{'propertiesToSet':{'%s':['testName3']}}", ContentModel.PROP_NAME.toString());
         final String comboPostBody = String.format("[{'url':'%s', 'method': 'post', 'body':%s}," +
-                    "{'url':'%s', 'method': 'get', 'body':%s}," +
-                    "{'url':'%s', 'method': 'post', 'body':%s}]",
-              firstUrlForRename, firstPostBody,
-              secondUrlForError, secndPostBody,
-              thirdUrlForRename, thirdPostBody);
+                        "{'url':'%s', 'method': 'get', 'body':%s}," +
+                        "{'url':'%s', 'method': 'post', 'body':%s}]",
+                firstUrlForRename, firstPostBody,
+                secondUrlForError, secndPostBody,
+                thirdUrlForRename, thirdPostBody);
 
         final String url = makeBulkUrl();
         final HttpPost post = new HttpPost(url);
@@ -260,9 +274,10 @@ public class BulkTest extends BaseTest {
 
     @Test
     public void testPutBulk() throws IOException {
-        NodeRef[] fileRef = init();
+        HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(fileRef[0]);
+        List<ChildParentAssociation> parentAssociations = this.nodeService
+                .getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
         NodeRef folderRef = primaryParentAssoc.getTarget();
 
@@ -277,32 +292,34 @@ public class BulkTest extends BaseTest {
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpPost httpPost = new HttpPost(url);
-        String firstPutUrl = removePrefixAndAuthenticate(makeNodesUrl(fileRef[0], "/parent", "admin", "admin"));
+        String firstPutUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/parent", "admin", "admin"));
         String firstJsonBody = String.format("{'parent':'%s'}", mainFolderRef);
         String jsonString = json(
-              String.format("[{'url':'%s', 'method':'%s', 'body':%s}]", firstPutUrl, "put", firstJsonBody));
+                String.format("[{'url':'%s', 'method':'%s', 'body':%s}]", firstPutUrl, "put", firstJsonBody));
         httpPost.setEntity(new StringEntity(jsonString));
 
         transactionService.getRetryingTransactionHelper()
-              .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                  @Override
-                  public Object execute() throws Throwable {
-                      try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
-                          assertEquals(200, response.getStatusLine().getStatusCode());
-                          List<ChildParentAssociation> newChildAssocs = nodeService
-                                .getChildAssociations(mainFolderRef);
-                          assertEquals(4, newChildAssocs.size());
-                      }
-                      return null;
-                  }
-              }, false, true);
+                .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
+                    @Override
+                    public Object execute() throws Throwable {
+                        try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+                            assertEquals(200, response.getStatusLine().getStatusCode());
+                            List<ChildParentAssociation> newChildAssocs = nodeService
+                                    .getChildAssociations(mainFolderRef);
+                            assertEquals(4, newChildAssocs.size());
+                        }
+                        return null;
+                    }
+                }, false, true);
     }
 
     @Test
     public void testDelete() throws IOException {
-        final NodeRef[] fileRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(fileRef[1]);
+        List<ChildParentAssociation> parentAssociations = this.nodeService
+                .getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE2_NAME));
         ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
         final NodeRef folderRef = primaryParentAssoc.getTarget();
 
@@ -313,41 +330,44 @@ public class BulkTest extends BaseTest {
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpPost httpPost = new HttpPost(url);
-        String firstDeleteUrl = removePrefixAndAuthenticate(makeNodesUrl(fileRef[1], "admin", "admin"));
+        String firstDeleteUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE2_NAME), "admin", "admin"));
         String jsonString = json(String.format("[{'url':'%s', 'method':'%s'}]", firstDeleteUrl, "delete"));
         httpPost.setEntity(new StringEntity(jsonString));
 
         transactionService.getRetryingTransactionHelper()
-              .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                  @Override
-                  public Object execute() throws Throwable {
-                      try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
-                          assertEquals(200, response.getStatusLine().getStatusCode());
-                          List<ChildParentAssociation> newChildAssocs = nodeService.getChildAssociations(folderRef);
-                          assertEquals(1, newChildAssocs.size());
-                      }
-                      return null;
-                  }
-              }, false, true);
-        String secondDeleteUrl = removePrefixAndAuthenticate(makeNodesUrl(fileRef[0], "?permanently=true", "admin",
-              "admin"));
+                .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
+                    @Override
+                    public Object execute() throws Throwable {
+                        try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+                            assertEquals(200, response.getStatusLine().getStatusCode());
+                            List<ChildParentAssociation> newChildAssocs = nodeService.getChildAssociations(folderRef);
+                            assertEquals(1, newChildAssocs.size());
+                        }
+                        return null;
+                    }
+                }, false, true);
+        String secondDeleteUrl = removePrefixAndAuthenticate(
+                makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "?permanently=true", "admin",
+                        "admin"));
         jsonString = json(String.format("[{'url':'%s', 'method':'%s', 'body':{}}]", secondDeleteUrl, "delete"));
         final HttpPost httpPost2 = new HttpPost(url);
         httpPost2.setEntity(new StringEntity(jsonString));
         transactionService.getRetryingTransactionHelper()
-              .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                  @Override
-                  public Object execute() throws Throwable {
-                      try (CloseableHttpResponse response = httpclient.execute(httpPost2)) {
-                          String result = EntityUtils.toString(response.getEntity());
-                          logger.info(" Result bulk delete post: " + result);
-                          assertEquals(200, response.getStatusLine().getStatusCode());
-                          assertFalse(alfrescoNodeService
-                                .exists(new org.alfresco.service.cmr.repository.NodeRef(fileRef[0].getValue())));
-                      }
-                      return null;
-                  }
-              });
+                .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
+                    @Override
+                    public Object execute() throws Throwable {
+                        try (CloseableHttpResponse response = httpclient.execute(httpPost2)) {
+                            String result = EntityUtils.toString(response.getEntity());
+                            logger.info(" Result bulk delete post: " + result);
+                            assertEquals(200, response.getStatusLine().getStatusCode());
+                            assertFalse(alfrescoNodeService
+                                    .exists(new org.alfresco.service.cmr.repository.NodeRef(
+                                            initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue())));
+                        }
+                        return null;
+                    }
+                });
     }
 
     @After

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/BulkTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/BulkTest.java
@@ -271,7 +271,7 @@ public class BulkTest extends BaseTest {
         final NodeRef mainFolderRef = primaryParentAssoc.getTarget();
 
         List<ChildParentAssociation> childAssocs = this.nodeService.getChildAssociations(mainFolderRef);
-        assertEquals(2, childAssocs.size());
+        assertEquals(3, childAssocs.size());
 
         String url = this.makeBulkUrl();
 
@@ -291,7 +291,7 @@ public class BulkTest extends BaseTest {
                           assertEquals(200, response.getStatusLine().getStatusCode());
                           List<ChildParentAssociation> newChildAssocs = nodeService
                                 .getChildAssociations(mainFolderRef);
-                          assertEquals(3, newChildAssocs.size());
+                          assertEquals(4, newChildAssocs.size());
                       }
                       return null;
                   }

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CheckoutCheckinTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CheckoutCheckinTest.java
@@ -48,7 +48,7 @@ public class CheckoutCheckinTest extends BaseTest {
     @Before
     public void setup() {
         AuthenticationUtil.setAdminUserAsFullyAuthenticatedUser();
-        originalNoderef = init()[0];
+        originalNoderef = init().get(BaseTest.TESTFILE_NAME);
     }
 
     @Test

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
@@ -4,6 +4,7 @@ import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.node.NodeAssociation;
 import eu.xenit.apix.node.ChildParentAssociation;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.transaction.TransactionService;
@@ -46,8 +47,8 @@ public class CopyNodeTest extends BaseTest {
 
     @Test
     public void testCopyNode() {
-        final NodeRef[] nodeRef = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[0]);
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
         final NodeRef parentRef = primaryParentAssoc.getTarget();
 
@@ -56,7 +57,7 @@ public class CopyNodeTest extends BaseTest {
 
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(() -> {
-                    doTestCopy(httpclient, url, parentRef, nodeRef[0].toString(), 200);
+                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.TESTFILE_NAME).toString(), 200);
                     return null;
                 }, false, true);
 
@@ -66,17 +67,17 @@ public class CopyNodeTest extends BaseTest {
 
     @Test
     public void copyNodeReturnsAccesDenied() {
-        final NodeRef[] initArray = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initArray[3]);
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME));
         final ChildParentAssociation primaryParentAssoc = parentAssociations.get(0);
         final NodeRef parentRef = primaryParentAssoc.getTarget();
 
-        final String url = makeAlfrescoBaseurl("red", "red") + "/apix/v1/nodes";
+        final String url = makeAlfrescoBaseurl(BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS) + "/apix/v1/nodes";
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(() -> {
-                    doTestCopy(httpclient, url, parentRef, initArray[3].toString(), 403);
+                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME).toString(), 403);
                     return null;
                 }, false, true);
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CreateNodeTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CreateNodeTest.java
@@ -7,6 +7,7 @@ import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.node.ChildParentAssociation;
 import eu.xenit.apix.node.INodeService;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
@@ -48,8 +49,8 @@ public class CreateNodeTest extends BaseTest {
 
     @Test
     public void testCreateNode() throws IOException {
-        final NodeRef[] nodeRef = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[0]);
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
         assertTrue(primaryParentAssoc.isPrimary());
         NodeRef parent = primaryParentAssoc.getTarget();
@@ -74,13 +75,13 @@ public class CreateNodeTest extends BaseTest {
 
     @Test
     public void testCreateNodeRespondsWithAccesDenied() throws IOException {
-        final NodeRef[] initArray = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initArray[3]);
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME));
         final ChildParentAssociation primaryParentAssoc = parentAssociations.get(0);
         NodeRef parent = primaryParentAssoc.getTarget();
         assertTrue(primaryParentAssoc.isPrimary());
 
-        final String url = makeAlfrescoBaseurl("red", "red") + "/apix/v1/nodes";
+        final String url = makeAlfrescoBaseurl(BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS) + "/apix/v1/nodes";
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/MoveNodeTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/MoveNodeTest.java
@@ -6,6 +6,7 @@ import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.node.ChildParentAssociation;
 import eu.xenit.apix.node.INodeService;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
@@ -44,9 +45,9 @@ public class MoveNodeTest extends BaseTest {
 
     @Test
     public void testMoveNode() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[0]);
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssocTestNode = (ChildParentAssociation) parentAssociations.get(0);
         final NodeRef testFolder = primaryParentAssocTestNode.getTarget();
 
@@ -70,7 +71,7 @@ public class MoveNodeTest extends BaseTest {
                     }
                 }, false, true);
 
-        final String url = this.makeNodesUrl(nodeRef[0], "/parent", "admin", "admin");
+        final String url = this.makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/parent", "admin", "admin");
         logger.info(" URL: " + url);
 
         doPut(url, null, "{\"parent\":\"%s\"}", mainTestFolder.toString());
@@ -83,9 +84,9 @@ public class MoveNodeTest extends BaseTest {
 
     @Test
     public void testMoveNodeReturnsAccesDenied() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(nodeRef[3]);
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME));
         final ChildParentAssociation primaryParentAssocTestNode = parentAssociations.get(0);
         final NodeRef testFolder = primaryParentAssocTestNode.getTarget();
 
@@ -93,7 +94,7 @@ public class MoveNodeTest extends BaseTest {
         final ChildParentAssociation primaryParentAssocTestFolder = parentAssociations.get(0);
         final NodeRef mainTestFolder = primaryParentAssocTestFolder.getTarget();
 
-        final String url = this.makeNodesUrl(nodeRef[3], "/parent", "red", "red");
+        final String url = this.makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/parent", BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS);
         logger.info(" URL: " + url);
         final CloseableHttpClient httpClient = HttpClients.createDefault();
         HttpPut httpPut = new HttpPut(url);

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/NodeContentTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/NodeContentTest.java
@@ -8,6 +8,7 @@ import eu.xenit.apix.node.INodeService;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.transaction.TransactionService;
@@ -50,9 +51,9 @@ public class NodeContentTest extends BaseTest {
 
     @Test
     public void testSetNodeContent() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        final String url = makeNodesUrl(nodeRef[0], "/content", "admin", "admin");
+        final String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/content", "admin", "admin");
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()
@@ -77,7 +78,8 @@ public class NodeContentTest extends BaseTest {
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     @Override
                     public Object execute() throws Throwable {
-                        InputStream inputStream = nodeService.getContent(nodeRef[0]).getInputStream();
+                        InputStream inputStream = nodeService
+                                .getContent(initializedNodeRefs.get(BaseTest.TESTFILE_NAME)).getInputStream();
                         assertEquals("test content123", IOUtils.toString(inputStream));
                         inputStream.close();
                         return null;
@@ -88,9 +90,10 @@ public class NodeContentTest extends BaseTest {
 
     @Test
     public void testSetNodeContentReturnsAccesDenied() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        final String url = makeNodesUrl(nodeRef[3], "/content", "red", "red");
+        final String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/content", BaseTest.USERWITHOUTRIGHTS,
+                BaseTest.USERWITHOUTRIGHTS);
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()
@@ -111,15 +114,16 @@ public class NodeContentTest extends BaseTest {
 
     @Test
     public void testDeleteNodeContent() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        final String url = makeNodesUrl(nodeRef[0], "/content", "admin", "admin");
+        final String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/content", "admin", "admin");
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     @Override
                     public Object execute() throws Throwable {
-                        nodeService.setContent(nodeRef[0], new ByteArrayInputStream("test contentabc".getBytes()),
+                        nodeService.setContent(initializedNodeRefs.get(BaseTest.TESTFILE_NAME),
+                                new ByteArrayInputStream("test contentabc".getBytes()),
                                 "abc.txt");
                         return null;
                     }
@@ -143,7 +147,7 @@ public class NodeContentTest extends BaseTest {
                     @Override
                     public Object execute() throws Throwable {
 
-                        assertNull(nodeService.getContent(nodeRef[0]));
+                        assertNull(nodeService.getContent(initializedNodeRefs.get(BaseTest.TESTFILE_NAME)));
                         return null;
                     }
                 }, false, true);
@@ -151,9 +155,10 @@ public class NodeContentTest extends BaseTest {
 
     @Test
     public void testDeleteNodeContentReturnsAccesDenied() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        final String url = makeNodesUrl(nodeRef[3], "/content", "red", "red");
+        final String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/content", BaseTest.USERWITHOUTRIGHTS,
+                BaseTest.USERWITHOUTRIGHTS);
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()
@@ -167,15 +172,16 @@ public class NodeContentTest extends BaseTest {
 
     @Test
     public void testGetNodeContent() throws IOException {
-        final NodeRef[] nodeRef = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        final String url = makeNodesUrl(nodeRef[0], "/content", "admin", "admin");
+        final String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/content", "admin", "admin");
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     @Override
                     public Object execute() throws Throwable {
-                        nodeService.setContent(nodeRef[0], new ByteArrayInputStream("test contentdef".getBytes()),
+                        nodeService.setContent(initializedNodeRefs.get(BaseTest.TESTFILE_NAME),
+                                new ByteArrayInputStream("test contentdef".getBytes()),
                                 "abc.txt");
                         return null;
                     }
@@ -199,10 +205,11 @@ public class NodeContentTest extends BaseTest {
     }
 
     @Test
-    public void testGetNodeContentReturnsAccesDenid() throws IOException {
-        final NodeRef[] nodeRef = init();
+    public void testGetNodeContentReturnsAccesDenied() throws IOException {
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
 
-        final String url = makeNodesUrl(nodeRef[3], "/content", "red", "red");
+        final String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/content", BaseTest.USERWITHOUTRIGHTS,
+                BaseTest.USERWITHOUTRIGHTS);
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/NodeContentTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/NodeContentTest.java
@@ -87,6 +87,29 @@ public class NodeContentTest extends BaseTest {
     }
 
     @Test
+    public void testSetNodeContentReturnsAccesDenied() throws IOException {
+        final NodeRef[] nodeRef = init();
+
+        final String url = makeNodesUrl(nodeRef[3], "/content", "red", "red");
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> {
+                    HttpPut httpput = new HttpPut(url);
+                    HttpEntity httpBody = MultipartEntityBuilder.create()
+                            .addBinaryBody("file", "test content123".getBytes(), ContentType.TEXT_PLAIN, "abc.txt")
+                            .build();
+                    httpput.setEntity(httpBody);
+
+                    try (CloseableHttpResponse response = httpclient.execute(httpput)) {
+                        assertEquals(403, response.getStatusLine().getStatusCode());
+                    }
+
+                    return null;
+                }, false, true);
+    }
+
+    @Test
     public void testDeleteNodeContent() throws IOException {
         final NodeRef[] nodeRef = init();
 
@@ -127,6 +150,22 @@ public class NodeContentTest extends BaseTest {
     }
 
     @Test
+    public void testDeleteNodeContentReturnsAccesDenied() throws IOException {
+        final NodeRef[] nodeRef = init();
+
+        final String url = makeNodesUrl(nodeRef[3], "/content", "red", "red");
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> {
+                    try (CloseableHttpResponse response = httpclient.execute(new HttpDelete(url))) {
+                        assertEquals(403, response.getStatusLine().getStatusCode());
+                    }
+                    return null;
+                }, false, true);
+    }
+
+    @Test
     public void testGetNodeContent() throws IOException {
         final NodeRef[] nodeRef = init();
 
@@ -156,6 +195,22 @@ public class NodeContentTest extends BaseTest {
                         }
                         return null;
                     }
+                }, false, true);
+    }
+
+    @Test
+    public void testGetNodeContentReturnsAccesDenid() throws IOException {
+        final NodeRef[] nodeRef = init();
+
+        final String url = makeNodesUrl(nodeRef[3], "/content", "red", "red");
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> {
+                    try (CloseableHttpResponse response = httpclient.execute(new HttpGet(url))) {
+                        assertEquals(403, response.getStatusLine().getStatusCode());
+                    }
+                    return null;
                 }, false, true);
     }
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PathTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PathTest.java
@@ -62,6 +62,15 @@ public class PathTest extends BaseTest {
     }
 
     @Test
+    public void testDisplayPathGetReturnsAccesDenied() throws IOException {
+        NodeRef[] nodeRef = init();
+        String url = makeNodesUrl(nodeRef[3], "/path", "red", "red");
+
+        HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
+        assertEquals(403, httpResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
     public void testQNamePathGet() throws IOException {
         NodeRef[] nodeRef = init();
         String url = makeNodesUrl(nodeRef[0], "/path", "admin", "admin");
@@ -75,6 +84,16 @@ public class PathTest extends BaseTest {
                 this.nodeService.getPath(new org.alfresco.service.cmr.repository.NodeRef(nodeRef[0].getValue()))
                         .toPrefixString(namespaceService));
         assertTrue(result.contains(expectedResult));
+    }
+
+    @Test
+    public void testQNamePathGetReturnsAccesDenied() throws IOException {
+        NodeRef[] nodeRef = init();
+        String url = makeNodesUrl(nodeRef[3], "/path", "red", "red");
+
+        HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
+
+        assertEquals(403, httpResponse.getStatusLine().getStatusCode());
     }
 
     @After

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PathTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PathTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import eu.xenit.apix.data.NodeRef;
 import java.io.IOException;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.security.PermissionService;
@@ -46,8 +47,8 @@ public class PathTest extends BaseTest {
 
     @Test
     public void testDisplayPathGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/path", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/path", "admin", "admin");
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(httpResponse.getEntity());
@@ -56,15 +57,15 @@ public class PathTest extends BaseTest {
         assertEquals(200, httpResponse.getStatusLine().getStatusCode());
 
         String expectedResult = String.format("\"displayPath\":\"%s\"",
-                this.nodeService.getPath(new org.alfresco.service.cmr.repository.NodeRef(nodeRef[0].getValue()))
+                this.nodeService.getPath(new org.alfresco.service.cmr.repository.NodeRef(initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()))
                         .toDisplayPath(this.nodeService, this.permissionService));
         assertTrue(result.contains(expectedResult));
     }
 
     @Test
     public void testDisplayPathGetReturnsAccesDenied() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[3], "/path", "red", "red");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/path", BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS);
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
         assertEquals(403, httpResponse.getStatusLine().getStatusCode());
@@ -72,8 +73,8 @@ public class PathTest extends BaseTest {
 
     @Test
     public void testQNamePathGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/path", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/path", "admin", "admin");
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(httpResponse.getEntity());
@@ -81,15 +82,15 @@ public class PathTest extends BaseTest {
 
         assertEquals(200, httpResponse.getStatusLine().getStatusCode());
         String expectedResult = String.format("\"qnamePath\":\"%s\"",
-                this.nodeService.getPath(new org.alfresco.service.cmr.repository.NodeRef(nodeRef[0].getValue()))
+                this.nodeService.getPath(new org.alfresco.service.cmr.repository.NodeRef(initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()))
                         .toPrefixString(namespaceService));
         assertTrue(result.contains(expectedResult));
     }
 
     @Test
     public void testQNamePathGetReturnsAccesDenied() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[3], "/path", "red", "red");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/path", BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS);
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PermissionsTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PermissionsTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -147,6 +148,48 @@ public class PermissionsTest extends BaseTest {
 
     }
 
+    @Test
+    public void testGetNodeAclsReturnsAccesDenied() throws IOException {
+        NodeRef[] nodeRef = init();
+        String url = makeNodesUrl(nodeRef[3], "/acl", "red", "red");
+
+        HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
+        logger.debug(EntityUtils.toString(httpResponse.getEntity()));
+        assertEquals(403, httpResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testSetNodeAclsReturnsAccesDenied() throws IOException {
+        NodeRef[] nodeRef = init();
+        String url = makeNodesUrl(nodeRef[0], "/acl", "red", "red");
+
+        HttpResponse httpResponse = Request.Put(url).body(new StringEntity(
+                "{\n"
+                        + "   \"inheritFromParent\": false,\n"
+                        + "   \"ownAccessList\": [\n"
+                        + "      {\n"
+                        + "         \"allowed\": true,\n"
+                        + "         \"authority\": \"red\",\n"
+                        + "         \"permission\": \"Collaborator\"\n"
+                        + "      }\n"
+                        + "]}"
+        )).execute().returnResponse();
+        logger.debug(EntityUtils.toString(httpResponse.getEntity()));
+        String result = EntityUtils.toString(httpResponse.getEntity());
+        assertEquals(403, httpResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testSetInheritFromParentReturnsAccesDenied() throws IOException {
+        NodeRef[] initArray = init();
+        assertEquals(403,
+                Request.Post(makeNodesUrl(initArray[3], "/acl/inheritFromParent", "red", "red"))
+                        .body(new StringEntity("{\"inheritFromParent\":true}"))
+                        .execute()
+                        .returnResponse()
+                        .getStatusLine()
+                        .getStatusCode());
+    }
 
     @After
     public void cleanUp() {

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PermissionsTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/PermissionsTest.java
@@ -1,9 +1,12 @@
 package eu.xenit.apix.rest.v1.tests;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import eu.xenit.apix.data.NodeRef;
 import java.io.IOException;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
@@ -34,8 +37,8 @@ public class PermissionsTest extends BaseTest {
 
     @Test
     public void testPermissionsGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/permissions", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/permissions", "admin", "admin");
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
         logger.debug(EntityUtils.toString(httpResponse.getEntity()));
@@ -45,8 +48,9 @@ public class PermissionsTest extends BaseTest {
 
     @Test
     public void testPermissionsShortGet() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0].getGuid(), "/permissions", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getGuid(), "/permissions", "admin",
+                "admin");
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
         logger.debug(EntityUtils.toString(httpResponse.getEntity()));
@@ -59,8 +63,8 @@ public class PermissionsTest extends BaseTest {
      */
     @Test
     public void testNodePermissionGetDefault() throws IOException, JSONException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0].getGuid(), "/acl", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getGuid(), "/acl", "admin", "admin");
 
         checkNoPermissionOnNode(url);
     }
@@ -97,8 +101,8 @@ public class PermissionsTest extends BaseTest {
      */
     @Test
     public void testNodePermissionApplyGetAndRemove() throws IOException, JSONException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0].getGuid(), "/acl", "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getGuid(), "/acl", "admin", "admin");
 
         doPut(url,
                 null,
@@ -150,8 +154,9 @@ public class PermissionsTest extends BaseTest {
 
     @Test
     public void testGetNodeAclsReturnsAccesDenied() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[3], "/acl", "red", "red");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/acl",
+                BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS);
 
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
         logger.debug(EntityUtils.toString(httpResponse.getEntity()));
@@ -160,8 +165,9 @@ public class PermissionsTest extends BaseTest {
 
     @Test
     public void testSetNodeAclsReturnsAccesDenied() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "/acl", "red", "red");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "/acl", BaseTest.USERWITHOUTRIGHTS,
+                BaseTest.USERWITHOUTRIGHTS);
 
         HttpResponse httpResponse = Request.Put(url).body(new StringEntity(
                 "{\n"
@@ -181,9 +187,11 @@ public class PermissionsTest extends BaseTest {
 
     @Test
     public void testSetInheritFromParentReturnsAccesDenied() throws IOException {
-        NodeRef[] initArray = init();
+        HashMap<String, NodeRef> initializedNodeRefs = init();
         assertEquals(403,
-                Request.Post(makeNodesUrl(initArray[3], "/acl/inheritFromParent", "red", "red"))
+                Request.Post(
+                        makeNodesUrl(initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/acl/inheritFromParent",
+                                BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS))
                         .body(new StringEntity("{\"inheritFromParent\":true}"))
                         .execute()
                         .returnResponse()

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/SetInheritParentPermissionsTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/SetInheritParentPermissionsTest.java
@@ -7,6 +7,7 @@ import eu.xenit.apix.permissions.IPermissionService;
 import eu.xenit.apix.rest.v2.tests.AllNodeInfoTest;
 import eu.xenit.apix.rest.v2.tests.BaseTest;
 import java.io.IOException;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.service.transaction.TransactionService;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -41,23 +42,17 @@ public class SetInheritParentPermissionsTest extends BaseTest {
     }
 
     @Test
-    public void testSetInheritPermissionsAPI() throws IOException, InterruptedException, JSONException {
-        NodeRef[] nodeRefs = init();
-        NodeRef nodeRef0 = nodeRefs[0];
-    }
-
-    @Test
     public void testSetInheritPermissionsRestTrue() throws IOException, InterruptedException, JSONException {
-        NodeRef[] nodeRefs = init();
-        NodeRef nodeRef0 = nodeRefs[0];
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        NodeRef nodeRef0 = initializedNodeRefs.get(BaseTest.TESTFILE_NAME);
         setInheritUrl(nodeRef0, true);
         assertInheritUrl(nodeRef0, true);
     }
 
     @Test
     public void testSetInheritPermissionsRestFalse() throws IOException, InterruptedException, JSONException {
-        NodeRef[] nodeRefs = init();
-        NodeRef nodeRef0 = nodeRefs[0];
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        NodeRef nodeRef0 = initializedNodeRefs.get(BaseTest.TESTFILE_NAME);
         setInheritUrl(nodeRef0, false);
         assertInheritUrl(nodeRef0, false);
     }

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/VersionHistoryTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/VersionHistoryTest.java
@@ -1,9 +1,15 @@
 package eu.xenit.apix.rest.v1.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
 import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.versionhistory.Version;
 import eu.xenit.apix.versionhistory.VersionHistory;
+import java.io.IOException;
+import java.util.HashMap;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
@@ -29,11 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-
-import java.io.IOException;
-import java.util.HashMap;
-
-import static org.junit.Assert.*;
 
 
 public class VersionHistoryTest extends BaseTest {
@@ -62,14 +63,13 @@ public class VersionHistoryTest extends BaseTest {
     //
     @Test
     public void testGetVersionHistorySimpleNode() throws IOException {
-
-        final NodeRef[] nodeRefs = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
         final String[] url = new String[1];
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     @Override
                     public Object execute() throws Throwable {
-                        NodeRef testNode = nodeRefs[2];
+                        NodeRef testNode = initializedNodeRefs.get(BaseTest.TESTFILE3_NAME);
                         url[0] = createApixUrl("/versionhistory/%s/%s/%s/versions", testNode.getStoreRefProtocol(),
                                 testNode.getStoreRefId(), testNode.getGuid());
                         HashMap versionProperties = new HashMap<>();
@@ -100,7 +100,7 @@ public class VersionHistoryTest extends BaseTest {
 
     @Test
     public void testSetVersionHistoryWithoutBody() throws IOException {
-        final NodeRef[] nodeRefs = init();
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
         final VersionService versionService = alfrizcoVersionHistoryService;
 
         final boolean defaultAutoVersion = dictionaryService.getProperty(ContentModel.PROP_AUTO_VERSION)
@@ -110,13 +110,16 @@ public class VersionHistoryTest extends BaseTest {
         final boolean defaultInitialVersion = dictionaryService.getProperty(ContentModel.PROP_INITIAL_VERSION)
                 .getDefaultValue().equals("true");
 
-        String versionHistoryUrl = createApixUrl("/versionhistory/%s/%s/%s", nodeRefs[0].getStoreRefProtocol(),
-                nodeRefs[0].getStoreRefId(), nodeRefs[0].getGuid());
+        String versionHistoryUrl = createApixUrl("/versionhistory/%s/%s/%s",
+                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getStoreRefProtocol(),
+                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getStoreRefId(),
+                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getGuid());
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     public Object execute() throws Throwable {
                         assertFalse(versionService
-                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[0].getValue())));
+                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(
+                                        initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue())));
                         return null;
                     }
                 }, true, true);
@@ -132,18 +135,23 @@ public class VersionHistoryTest extends BaseTest {
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     public Object execute() throws Throwable {
                         assertTrue(alfrizcoVersionHistoryService
-                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[0].getValue())));
+                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(
+                                        initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue())));
                         assertEquals(defaultAutoVersion, nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[0].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()),
                                         ContentModel.PROP_AUTO_VERSION));
                         assertEquals(defaultAutoVersionProps, nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[0].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()),
                                         ContentModel.PROP_AUTO_VERSION_PROPS));
                         assertEquals(defaultInitialVersion, nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[0].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()),
                                         ContentModel.PROP_INITIAL_VERSION));
                         assertEquals("1.0", nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[0].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE_NAME).getValue()),
                                         ContentModel.PROP_VERSION_LABEL));
                         return null;
                     }
@@ -153,13 +161,16 @@ public class VersionHistoryTest extends BaseTest {
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     public Object execute() throws Throwable {
                         assertFalse(alfrizcoVersionHistoryService
-                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[1].getValue())));
+                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(
+                                        initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue())));
                         return null;
                     }
                 }, true, true);
 
-        String versionHistoryUrl2 = createApixUrl("/versionhistory/%s/%s/%s", nodeRefs[1].getStoreRefProtocol(),
-                nodeRefs[1].getStoreRefId(), nodeRefs[1].getGuid());
+        String versionHistoryUrl2 = createApixUrl("/versionhistory/%s/%s/%s",
+                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getStoreRefProtocol(),
+                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getStoreRefId(),
+                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getGuid());
         String requestBody = "{" +
                 "'autoVersion': false," +
                 "'autoVersionOnUpdateProps': true," +
@@ -179,18 +190,23 @@ public class VersionHistoryTest extends BaseTest {
                 .doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
                     public Object execute() throws Throwable {
                         assertTrue(alfrizcoVersionHistoryService
-                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[1].getValue())));
+                                .isVersioned(new org.alfresco.service.cmr.repository.NodeRef(
+                                        initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue())));
                         assertEquals(false, nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[1].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue()),
                                         ContentModel.PROP_AUTO_VERSION));
                         assertEquals(true, nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[1].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue()),
                                         ContentModel.PROP_AUTO_VERSION_PROPS));
                         assertEquals(false, nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[1].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue()),
                                         ContentModel.PROP_INITIAL_VERSION));
                         assertEquals("1.0", nodeService
-                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(nodeRefs[1].getValue()),
+                                .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
+                                                initializedNodeRefs.get(BaseTest.TESTFILE2_NAME).getValue()),
                                         ContentModel.PROP_VERSION_LABEL));
                         return null;
                     }

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/temp/UploadFileTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/temp/UploadFileTest.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
@@ -52,7 +53,7 @@ public class UploadFileTest extends BaseTest {
     private NodeService alfrescoNodeService;
     private ContentService contentService;
     private NodeRef parentNodeRef;
-    private NodeRef[] initNodeRefArray;
+    private Map<String, NodeRef> initNodeRefArray;
 
     @org.junit.Before
     public void setUp() {
@@ -61,7 +62,7 @@ public class UploadFileTest extends BaseTest {
         contentService = this.serviceRegistry.getContentService();
 
         initNodeRefArray = init();
-        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initNodeRefArray[0]);
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initNodeRefArray.get(BaseTest.TESTFILE_NAME));
         final ChildParentAssociation primaryParentAssoc = parentAssociations.get(0);
         this.parentNodeRef = primaryParentAssoc.getTarget();
         assertTrue(primaryParentAssoc.isPrimary());
@@ -86,9 +87,9 @@ public class UploadFileTest extends BaseTest {
 
     @Test
     public void testUploadFileResultsInAccessDenied() throws IOException {
-        String url = createUrl("red", "red");
+        String url = createUrl(BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS);
         logger.info(">>>>> URL: " + url);
-        HttpEntity entity = createHttpEntity(initNodeRefArray[3].toString());
+        HttpEntity entity = createHttpEntity(initNodeRefArray.get(BaseTest.NOUSERRIGHTS_FILE_NAME).toString());
         try (CloseableHttpResponse response = doPost(url, entity)) {
             String resultString = EntityUtils.toString(response.getEntity());
             logger.debug(" resultString: " + resultString);

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.rest.v2.tests;
 
 import eu.xenit.apix.data.NodeRef;
+import java.util.HashMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
@@ -22,7 +23,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
-public class AllNodeInfoTest extends BaseTest {
+public class AllNodeInfoTest extends eu.xenit.apix.rest.v2.tests.BaseTest {
 
     private final static Logger logger = LoggerFactory.getLogger(AllNodeInfoTest.class);
 
@@ -33,8 +34,8 @@ public class AllNodeInfoTest extends BaseTest {
 
     @Test
     public void testGetAllNodeInfo() throws IOException {
-        NodeRef[] nodeRef = init();
-        String url = makeNodesUrl(nodeRef[0], "admin", "admin");
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url = makeNodesUrl(initializedNodeRefs.get(BaseTest.TESTFILE_NAME), "admin", "admin");
         logger.info(" URL: " + url);
         for (int i = 0; i < 20; i++) {
             logger.error("For the request of testGetAllNodeInfo");
@@ -49,9 +50,9 @@ public class AllNodeInfoTest extends BaseTest {
 
     @Test
     public void testGetAllNodeInfoOfMultipleNodes() throws IOException, JSONException {
-        NodeRef[] nodeRefs = init();
-        NodeRef nodeRef0 = nodeRefs[0];
-        NodeRef nodeRef1 = nodeRefs[1];
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        NodeRef nodeRef0 = initializedNodeRefs.get(BaseTest.TESTFILE_NAME);
+        NodeRef nodeRef1 = initializedNodeRefs.get(BaseTest.TESTFILE2_NAME);
 
         String jsonString = json(String.format(
                 "{" +

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -623,8 +623,7 @@ public class NodesWebscript1 extends ApixV1Webscript {
     public void getContent(@UriVariable String space, @UriVariable String store, @UriVariable String guid,
             WebScriptResponse response) throws IOException {
         final NodeRef nodeRef = new NodeRef(space, store, guid);
-        ContentInputStream contentInputStream = null;
-        contentInputStream = nodeService.getContent(nodeRef);
+        ContentInputStream contentInputStream = nodeService.getContent(nodeRef);
         if (contentInputStream == null) {
             response.setStatus(404);
             return;

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     de_version = "2.0.1"
 
     http_core_version = "4.3.3"
-    http_version = "4.3.3"
+    http_version = "4.3.4"
 
     alfresco_50_version = "5.0.d"
     alfresco_51_version = "5.1.f"


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-421

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.

> Pr adds explicit ApiResponse 403 to NodesWebscript endpoints

- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
