### PR TITLE
Replace terms with property values that will cause Invalid Number Exceptions in Solr 6 with dummy terms in FtsNodeVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint
 * [ALFREDAPI-422](https://xenitsupport.jira.com/browse/ALFREDAPI-422): Fix totalResults and limits for TDMQ's
+* [ALFREDAPI-427](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Replace terms with property values that will cause Invalid Number Exceptions in Solr 6 with dummy terms in FtsNodeVisitor
+
 ### Deleted
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint
 * [ALFREDAPI-422](https://xenitsupport.jira.com/browse/ALFREDAPI-422): Fix totalResults and limits for TDMQ's
-* [ALFREDAPI-427](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Replace terms with property values that will cause Invalid Number Exceptions in Solr 6 with dummy terms in FtsNodeVisitor
+* [ALFREDAPI-427](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Add workaround to prevent Solr Exceptions when searching for numeric values that overflow when parsed as int or long
 
 ### Deleted
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -34,7 +34,6 @@ import org.alfresco.service.transaction.TransactionService;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -321,5 +320,32 @@ abstract public class SearchServiceTest extends BaseTest {
      * Implemented in alfresco version specific subclasses to set up and tear down solr facets.
      */
     abstract protected void withTestFacets(AuthenticationUtil.RunAsWork<Object> work) throws Exception;
+
+
+    @Test
+    public void testNotFilteredOut() {
+        SearchSyntaxNode node =
+                new QueryBuilder()
+                        .startOr()
+                        .property("{http://www.alfresco.org/model/system/1.0}node-dbid", "9223372036854775807")
+                        .end()
+                        .create();
+        SearchQuery searchQuery = new SearchQuery();
+        searchQuery.setQuery(node);
+        searchService.query(searchQuery);
+    }
+
+    @Test
+    public void testNothingLeftAfterFiltering() {
+        SearchSyntaxNode node =
+                new QueryBuilder()
+                        .startOr()
+                        .property("{http://www.alfresco.org/model/system/1.0}node-dbid", "9223372036854775808")
+                        .end()
+                        .create();
+        SearchQuery searchQuery = new SearchQuery();
+        searchQuery.setQuery(node);
+        searchService.query(searchQuery);
+    }
 
 }

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -14,6 +14,7 @@ import eu.xenit.apix.tests.BaseTest;
 import eu.xenit.apix.util.SolrTestHelper;
 import java.io.IOException;
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.util.Locale;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -42,6 +43,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.extensions.surf.util.I18NUtil;
 
 abstract public class SearchServiceTest extends BaseTest {
+
+    private static final String LONG_MAX_VALUE = String.valueOf(Long.MAX_VALUE);
+    private static final String LONG_MAX_VALUE_PLUS_ONE = new BigInteger(LONG_MAX_VALUE).add(new BigInteger("1"))
+            .toString();
 
     private final static Logger logger = LoggerFactory.getLogger(SearchServiceTest.class);
     private static final String ADMIN_USER_NAME = "admin";
@@ -323,11 +328,11 @@ abstract public class SearchServiceTest extends BaseTest {
 
 
     @Test
-    public void testNotFilteredOut() {
+    public void validLong_onlyNode_doesNotThrowException() {
         SearchSyntaxNode node =
                 new QueryBuilder()
                         .startOr()
-                        .property("{http://www.alfresco.org/model/system/1.0}node-dbid", "9223372036854775807")
+                        .property("{http://www.alfresco.org/model/system/1.0}node-dbid", LONG_MAX_VALUE)
                         .end()
                         .create();
         SearchQuery searchQuery = new SearchQuery();
@@ -336,11 +341,11 @@ abstract public class SearchServiceTest extends BaseTest {
     }
 
     @Test
-    public void testNothingLeftAfterFiltering() {
+    public void invalidLong_onlyNode_doesNotThrowException() {
         SearchSyntaxNode node =
                 new QueryBuilder()
                         .startOr()
-                        .property("{http://www.alfresco.org/model/system/1.0}node-dbid", "9223372036854775808")
+                        .property("{http://www.alfresco.org/model/system/1.0}node-dbid", LONG_MAX_VALUE_PLUS_ONE)
                         .end()
                         .create();
         SearchQuery searchQuery = new SearchQuery();

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -5,8 +5,6 @@ import eu.xenit.apix.properties.PropertyDefinition;
 import eu.xenit.apix.search.nodes.PropertySearchNode;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -13,12 +13,11 @@ public class PropertyTypeCheckService {
 
     private final static Logger logger = LoggerFactory.getLogger(PropertyTypeCheckService.class);
 
-    private final Map<String, Predicate<String>> dataTypePredicates = new HashMap<String, Predicate<String>>() {{
-        put("d:int", PropertyTypeCheckService::isInt);
-        put("{http://www.alfresco.org/model/dictionary/1.0}int", PropertyTypeCheckService::isInt);
-        put("d:long", PropertyTypeCheckService::isLong);
-        put("{http://www.alfresco.org/model/dictionary/1.0}long", PropertyTypeCheckService::isLong);
-    }};
+    private final static Map<String, Predicate<String>> dataTypePredicates = new HashMap<>();
+    static {
+        dataTypePredicates.put("{http://www.alfresco.org/model/dictionary/1.0}int", PropertyTypeCheckService::isInt);
+        dataTypePredicates.put("{http://www.alfresco.org/model/dictionary/1.0}long", PropertyTypeCheckService::isLong);
+    }
 
     private final PropertyService propertyService;
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -40,12 +40,11 @@ public class PropertyTypeCheckService {
         if (propertyDefinition == null || propertyDefinition.getDataType() == null) {
             return true;
         }
-        for (Entry<String, Predicate<String>> entry : dataTypePredicates.entrySet()) {
-            if (entry.getKey().equals(propertyDefinition.getDataType().getValue())) {
-                return entry.getValue().test(node.getValue());
-            }
+        Predicate<String> predicate = dataTypePredicates.get(propertyDefinition.getDataType().getValue());
+        if (predicate == null) {
+            return true;
         }
-        return true;
+        return predicate.test(node.getValue());
     }
 
     private static boolean isInt(String value) {

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -1,6 +1,5 @@
 package eu.xenit.apix.alfresco.dictionary;
 
-import eu.xenit.apix.alfresco.search.FtsNodeVisitor;
 import eu.xenit.apix.data.QName;
 import eu.xenit.apix.properties.PropertyDefinition;
 import eu.xenit.apix.search.nodes.PropertySearchNode;
@@ -8,8 +7,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PropertyTypeCheckService {
+
+    private final static Logger logger = LoggerFactory.getLogger(PropertyTypeCheckService.class);
 
     private final Map<String, Function<String, Boolean>> constraintMap = new HashMap<String, Function<String, Boolean>>() {{
         put("d:int", PropertyTypeCheckService::isInt);
@@ -21,6 +24,9 @@ public class PropertyTypeCheckService {
     private final PropertyService propertyService;
 
     public PropertyTypeCheckService(PropertyService propertyService) {
+        if (propertyService == null) {
+            logger.warn("Instantiating PropertyTypeCheckService without a PropertyService, type checks will always succeed");
+        }
         this.propertyService = propertyService;
     }
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -1,0 +1,62 @@
+package eu.xenit.apix.alfresco.dictionary;
+
+import eu.xenit.apix.alfresco.search.FtsNodeVisitor;
+import eu.xenit.apix.data.QName;
+import eu.xenit.apix.properties.PropertyDefinition;
+import eu.xenit.apix.search.nodes.PropertySearchNode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+
+public class PropertyTypeCheckService {
+
+    private final Map<String, Function<String, Boolean>> constraintMap = new HashMap<String, Function<String, Boolean>>() {{
+        put("d:int", PropertyTypeCheckService::isInt);
+        put("{http://www.alfresco.org/model/dictionary/1.0}int", PropertyTypeCheckService::isInt);
+        put("d:long", PropertyTypeCheckService::isLong);
+        put("{http://www.alfresco.org/model/dictionary/1.0}long", PropertyTypeCheckService::isLong);
+    }};
+
+    private final PropertyService propertyService;
+
+    public PropertyTypeCheckService(PropertyService propertyService) {
+        this.propertyService = propertyService;
+    }
+
+    public boolean fitsType(PropertySearchNode node) {
+        if (node == null || node.getValue() == null || node.getName() == null || propertyService == null) {
+            return true;
+        }
+        QName qName = new QName(node.getName().replaceAll("\\\\", "")); //stuff like hyphen in node-dbid is escaped
+        PropertyDefinition propertyDefinition = propertyService.GetPropertyDefinition(qName);
+        if (propertyDefinition == null || propertyDefinition.getDataType() == null) {
+            return true;
+        }
+        for (Entry<String, Function<String, Boolean>> entry : constraintMap.entrySet()) {
+            if (entry.getKey().equals(propertyDefinition.getDataType().getValue())) {
+                return entry.getValue().apply(node.getValue());
+            }
+        }
+        return true;
+    }
+
+    private static boolean isInt(String value) {
+        try {
+            Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isLong(String value) {
+        try {
+            Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +15,7 @@ public class PropertyTypeCheckService {
 
     private final static Logger logger = LoggerFactory.getLogger(PropertyTypeCheckService.class);
 
-    private final Map<String, Function<String, Boolean>> constraintMap = new HashMap<String, Function<String, Boolean>>() {{
+    private final Map<String, Predicate<String>> dataTypePredicates = new HashMap<String, Predicate<String>>() {{
         put("d:int", PropertyTypeCheckService::isInt);
         put("{http://www.alfresco.org/model/dictionary/1.0}int", PropertyTypeCheckService::isInt);
         put("d:long", PropertyTypeCheckService::isLong);
@@ -39,9 +40,9 @@ public class PropertyTypeCheckService {
         if (propertyDefinition == null || propertyDefinition.getDataType() == null) {
             return true;
         }
-        for (Entry<String, Function<String, Boolean>> entry : constraintMap.entrySet()) {
+        for (Entry<String, Predicate<String>> entry : dataTypePredicates.entrySet()) {
             if (entry.getKey().equals(propertyDefinition.getDataType().getValue())) {
-                return entry.getValue().apply(node.getValue());
+                return entry.getValue().test(node.getValue());
             }
         }
         return true;

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/PropertyTypeCheckService.java
@@ -35,7 +35,7 @@ public class PropertyTypeCheckService {
         if (node == null || node.getValue() == null || node.getName() == null || propertyService == null) {
             return true;
         }
-        QName qName = new QName(node.getName().replaceAll("\\\\", "")); //stuff like hyphen in node-dbid is escaped
+        QName qName = new QName(PropertySearchNode.unescapeName(node.getName()));
         PropertyDefinition propertyDefinition = propertyService.GetPropertyDefinition(qName);
         if (propertyDefinition == null || propertyDefinition.getDataType() == null) {
             return true;

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
@@ -26,6 +26,7 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
     private final PropertyService propertyService;
     private final Map<String, Function<String, Boolean>> constraintMap = new HashMap<String, Function<String, Boolean>>() {{
         put("d:int", FtsNodeVisitor::isInt);
+        put("d:long", FtsNodeVisitor::isLong);
     }};
 
     public FtsNodeVisitor() {
@@ -189,6 +190,15 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
     private static boolean isInt(String value) {
         try {
             Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isLong(String value) {
+        try {
+            Long.parseLong(value);
         } catch (NumberFormatException e) {
             return false;
         }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
@@ -62,10 +62,7 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
         //String s = ;
         List<String> children = new ArrayList<>(n.getChildren().size());
         for (SearchSyntaxNode node : n.getChildren()) {
-            String result = visit(node);
-            if (result != null) {
-                children.add(result);
-            }
+            children.add(visit(node));
         }
 
 //        String s = String.join(" " + n.getOperator() + " ", n.getChildren().stream().map(el -> visit(el)).collect(Collectors.toList()));
@@ -81,7 +78,7 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
     @Override
     public String visit(PropertySearchNode n) {
         if (!propertyTypeCheckService.fitsType(n)) {
-            return null;
+            return "_dummy_:_miss_";
         }
         builder.setLength(0);
         if (n.isExact()) {

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
@@ -62,12 +62,14 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
         //String s = ;
         List<String> children = new ArrayList<>(n.getChildren().size());
         for (SearchSyntaxNode node : n.getChildren()) {
-            children.add(visit(node));
+            String result = visit(node);
+            if (result != null) {
+                children.add(result);
+            }
         }
 
 //        String s = String.join(" " + n.getOperator() + " ", n.getChildren().stream().map(el -> visit(el)).collect(Collectors.toList()));
-        String s = StringUtils.join(" " + n.getOperator() + " ", children.stream().filter(Objects::nonNull).collect(
-                Collectors.toList()));
+        String s = StringUtils.join(" " + n.getOperator() + " ", children);
         builder.setLength(0);
         builder.append('(');
         builder.append(s);

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
@@ -26,7 +26,9 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
     private final PropertyService propertyService;
     private final Map<String, Function<String, Boolean>> constraintMap = new HashMap<String, Function<String, Boolean>>() {{
         put("d:int", FtsNodeVisitor::isInt);
+        put("{http://www.alfresco.org/model/dictionary/1.0}int", FtsNodeVisitor::isInt);
         put("d:long", FtsNodeVisitor::isLong);
+        put("{http://www.alfresco.org/model/dictionary/1.0}long", FtsNodeVisitor::isLong);
     }};
 
     public FtsNodeVisitor() {
@@ -175,7 +177,8 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
         if (node == null || node.getValue() == null || node.getName() == null || propertyService == null) {
             return true;
         }
-        PropertyDefinition propertyDefinition = propertyService.GetPropertyDefinition(new QName(node.getName()));
+        QName qName = new QName(node.getName().replaceAll("\\\\", "")); //stuff like hyphen in node-dbid is escaped
+        PropertyDefinition propertyDefinition = propertyService.GetPropertyDefinition(qName);
         if (propertyDefinition == null || propertyDefinition.getDataType() == null) {
             return true;
         }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/FtsNodeVisitor.java
@@ -2,25 +2,24 @@ package eu.xenit.apix.alfresco.search;
 
 import eu.xenit.apix.alfresco.dictionary.PropertyService;
 import eu.xenit.apix.alfresco.dictionary.PropertyTypeCheckService;
-import eu.xenit.apix.data.QName;
-import eu.xenit.apix.properties.PropertyDefinition;
-import eu.xenit.apix.search.nodes.*;
+import eu.xenit.apix.search.nodes.InvertSearchNode;
+import eu.xenit.apix.search.nodes.OperatorSearchNode;
+import eu.xenit.apix.search.nodes.PropertySearchNode;
+import eu.xenit.apix.search.nodes.RangeValue;
+import eu.xenit.apix.search.nodes.SearchSyntaxNode;
+import eu.xenit.apix.search.nodes.TermSearchNode;
 import eu.xenit.apix.search.visitors.BaseSearchSyntaxNodeVisitor;
 import eu.xenit.apix.utils.StringUtils;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Created by Michiel Huygen on 12/11/2015.
  */
 public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
+
+    private static final String DUMMY = "_dummy_:_miss_";
 
     private StringBuilder builder = new StringBuilder();
     private HashMap<String, String> termToFtsTerm = new HashMap<>();
@@ -78,7 +77,7 @@ public class FtsNodeVisitor extends BaseSearchSyntaxNodeVisitor<String> {
     @Override
     public String visit(PropertySearchNode n) {
         if (!propertyTypeCheckService.fitsType(n)) {
-            return "_dummy_:_miss_";
+            return DUMMY;
         }
         builder.setLength(0);
         if (n.isExact()) {

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
@@ -57,7 +57,7 @@ public class SearchService implements ISearchService {
         this.propertyService = propertyService;
     }
 
-    public String toFtsQuery(SearchQuery q, PropertyService propertyService) {
+    public String toFtsQuery(SearchQuery q) {
         FtsNodeVisitor ftsNodeVisitor = new FtsNodeVisitor(propertyService);
         return ftsNodeVisitor.visit(q.getQuery());
     }
@@ -72,7 +72,7 @@ public class SearchService implements ISearchService {
 
         SearchParameters searchParameters = new SearchParameters();
 
-        String query = toFtsQuery(postQuery, propertyService);
+        String query = toFtsQuery(postQuery);
         int argSkipCount = postQuery.getPaging().getSkip();
 
         // Max items

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
@@ -57,8 +57,8 @@ public class SearchService implements ISearchService {
         this.propertyService = propertyService;
     }
 
-    public String toFtsQuery(SearchQuery q) {
-        FtsNodeVisitor ftsNodeVisitor = new FtsNodeVisitor();
+    public String toFtsQuery(SearchQuery q, PropertyService propertyService) {
+        FtsNodeVisitor ftsNodeVisitor = new FtsNodeVisitor(propertyService);
         return ftsNodeVisitor.visit(q.getQuery());
     }
 
@@ -72,7 +72,7 @@ public class SearchService implements ISearchService {
 
         SearchParameters searchParameters = new SearchParameters();
 
-        String query = toFtsQuery(postQuery);
+        String query = toFtsQuery(postQuery, propertyService);
         int argSkipCount = postQuery.getPaging().getSkip();
 
         // Max items

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
@@ -24,9 +24,9 @@ public class FtsNodeVisitorTest {
     private final static Logger logger = LoggerFactory.getLogger(FtsNodeVisitorTest.class);
 
     private Map<QName, String> propertyToDataType = new HashMap<QName, String>() {{
-        put(new QName("{tenant.model}stringProperty1"), "d:text");
-        put(new QName("{tenant.model}stringProperty2"), "d:text");
-        put(new QName("{tenant.model}intProperty"), "d:int");
+        put(new QName("{tenant.model}stringProperty1"), "{http://www.alfresco.org/model/dictionary/1.0}text");
+        put(new QName("{tenant.model}stringProperty2"), "{http://www.alfresco.org/model/dictionary/1.0}text");
+        put(new QName("{tenant.model}intProperty"), "{http://www.alfresco.org/model/dictionary/1.0}int");
     }};
 
     @Test

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
@@ -3,8 +3,6 @@ package eu.xenit.apix.tests.search;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,9 +26,9 @@ public class FtsNodeVisitorTest {
     private final static Logger logger = LoggerFactory.getLogger(FtsNodeVisitorTest.class);
 
     private Map<String, String> propertyToDataType = new HashMap<String, String>() {{
-        put("{tenant}stringProperty1", "d:text");
-        put("{tenant}stringProperty2", "d:text");
-        put("{tenant}intProperty", "d:int");
+        put("{tenant.model}stringProperty1", "d:text");
+        put("{tenant.model}stringProperty2", "d:text");
+        put("{tenant.model}intProperty", "d:int");
     }};
 
     @Test
@@ -40,11 +38,11 @@ public class FtsNodeVisitorTest {
 
         String ftsQuery = toFts(querySyntaxTree, propertyService);
         assertThat("Fts search String does not contain wanted term", ftsQuery,
-                containsString("{tenant}stringProperty1"));
+                containsString("{tenant.model}stringProperty1"));
         assertThat("Fts search String does not contain wanted term", ftsQuery,
-                containsString("{tenant}stringProperty2"));
+                containsString("{tenant.model}stringProperty2"));
         assertThat("Fts search String contains term that shoud have been filtered out", ftsQuery,
-                not(containsString("{tenant}intProperty")));
+                not(containsString("{tenant.model}intProperty")));
     }
 
     @Test
@@ -54,11 +52,11 @@ public class FtsNodeVisitorTest {
 
         String ftsQuery = toFts(querySyntaxTree, propertyService);
         assertThat("Fts search String does not contain wanted term", ftsQuery,
-                containsString("{tenant}stringProperty1"));
+                containsString("{tenant.model}stringProperty1"));
         assertThat("Fts search String does not contain wanted term", ftsQuery,
-                containsString("{tenant}stringProperty2"));
+                containsString("{tenant.model}stringProperty2"));
         assertThat("Fts search String does not contain wanted term", ftsQuery,
-                containsString("{tenant}intProperty"));
+                containsString("{tenant.model}intProperty"));
     }
 
     private SearchSyntaxNode generateAllQuery(String value) {

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
@@ -81,7 +81,7 @@ public class FtsNodeVisitorTest {
         return ret;
     }
 
-    private static class PropertyServiceStub extends PropertyService{
+    private static class PropertyServiceStub extends PropertyService {
 
         final Map<QName, String> propertyToDataType;
 

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
@@ -1,0 +1,98 @@
+package eu.xenit.apix.tests.search;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.xenit.apix.alfresco.dictionary.PropertyService;
+import eu.xenit.apix.alfresco.search.FtsNodeVisitor;
+import eu.xenit.apix.data.QName;
+import eu.xenit.apix.properties.PropertyDefinition;
+import eu.xenit.apix.search.QueryBuilder;
+import eu.xenit.apix.search.nodes.SearchSyntaxNode;
+import eu.xenit.apix.search.visitors.SearchSyntaxPrinter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class FtsNodeVisitorTest {
+
+    private final static Logger logger = LoggerFactory.getLogger(FtsNodeVisitorTest.class);
+
+    private Map<String, String> propertyToDataType = new HashMap<String, String>() {{
+        put("{tenant}stringProperty1", "d:text");
+        put("{tenant}stringProperty2", "d:text");
+        put("{tenant}intProperty", "d:int");
+    }};
+
+    @Test
+    public void testIntTypeInvalid() {
+        SearchSyntaxNode querySyntaxTree = generateAllQuery("5500012345");
+        PropertyService propertyService = generatePropertyServiceMock();
+
+        String ftsQuery = toFts(querySyntaxTree, propertyService);
+        assertThat("Fts search String does not contain wanted term", ftsQuery,
+                containsString("{tenant}stringProperty1"));
+        assertThat("Fts search String does not contain wanted term", ftsQuery,
+                containsString("{tenant}stringProperty2"));
+        assertThat("Fts search String contains term that shoud have been filtered out", ftsQuery,
+                not(containsString("{tenant}intProperty")));
+    }
+
+    @Test
+    public void testIntTypeValid() {
+        SearchSyntaxNode querySyntaxTree = generateAllQuery("1500012345");
+        PropertyService propertyService = generatePropertyServiceMock();
+
+        String ftsQuery = toFts(querySyntaxTree, propertyService);
+        assertThat("Fts search String does not contain wanted term", ftsQuery,
+                containsString("{tenant}stringProperty1"));
+        assertThat("Fts search String does not contain wanted term", ftsQuery,
+                containsString("{tenant}stringProperty2"));
+        assertThat("Fts search String does not contain wanted term", ftsQuery,
+                containsString("{tenant}intProperty"));
+    }
+
+    private SearchSyntaxNode generateAllQuery(String value) {
+        QueryBuilder querySyntaxTree = new QueryBuilder()
+                .startAnd()
+                .startOr();
+        for (String property : propertyToDataType.keySet()) {
+            querySyntaxTree = querySyntaxTree.property(property, value);
+        }
+        return querySyntaxTree
+                .end()
+                .term("type", "{http://www.alfresco.org/model/content/1.0}content")
+                .end()
+                .create();
+    }
+
+    private PropertyService generatePropertyServiceMock() {
+        PropertyService propertyService = mock(PropertyService.class);
+        for (Entry<String, String> entry : propertyToDataType.entrySet()) {
+            PropertyDefinition def = new PropertyDefinition();
+            def.setDataType(new QName(entry.getValue()));
+            when(propertyService.GetPropertyDefinition(new QName(entry.getKey())))
+                    .thenReturn(def);
+        }
+        return propertyService;
+    }
+
+
+    private String toFts(SearchSyntaxNode node, PropertyService propertyService) {
+        logger.debug(SearchSyntaxPrinter.Print(node));
+        FtsNodeVisitor visitor = new FtsNodeVisitor(propertyService);
+        String ret = visitor.visit(node);
+
+        logger.debug(ret);
+        return ret;
+    }
+}

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/FtsNodeVisitorTest.java
@@ -3,7 +3,6 @@ package eu.xenit.apix.tests.search;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 
 import eu.xenit.apix.alfresco.dictionary.PropertyService;
 import eu.xenit.apix.alfresco.search.FtsNodeVisitor;

--- a/apix-interface/src/main/java/eu/xenit/apix/search/nodes/PropertySearchNode.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/search/nodes/PropertySearchNode.java
@@ -7,6 +7,8 @@ import eu.xenit.apix.search.visitors.ISearchSyntaxVisitor;
  */
 public class PropertySearchNode implements SearchSyntaxNode {
 
+    private static final String ESCAPE_GROUP_REGEX = "([!@%^&*()\\-=+\\[\\];?,<>|])";
+
     private String name;
     private String value;
     private RangeValue range;
@@ -41,8 +43,7 @@ public class PropertySearchNode implements SearchSyntaxNode {
         // Solr queries where the property name contains any of the characters in the regex below trigger an error
         // in solr. This error is propagated through alfresco and apix. To prevent this, we escape the characters
         // before the terms enter solr.
-        String replacement = name.replaceAll("([!@%^&*()\\-=+\\[\\];?,<>|])", "\\\\$1");
-        this.name = replacement;
+        this.name = escapeName(name);
     }
 
     public String getValue() {
@@ -72,5 +73,13 @@ public class PropertySearchNode implements SearchSyntaxNode {
 
     public void setExact(boolean exact) {
         this.exact = exact;
+    }
+
+    public static String escapeName(String name) {
+        return name.replaceAll(ESCAPE_GROUP_REGEX, "\\\\$1");
+    }
+
+    public static String unescapeName(String name) {
+        return name.replaceAll("\\\\" + ESCAPE_GROUP_REGEX, "$1");
     }
 }

--- a/apix-interface/src/test/java/eu/xenit/apix/search/nodes/PropertySearchNodeTest.java
+++ b/apix-interface/src/test/java/eu/xenit/apix/search/nodes/PropertySearchNodeTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class PropertySearchNodeTest {
@@ -25,6 +26,31 @@ public class PropertySearchNodeTest {
             searchNode.setName("sys:store" + specialChar + "identifier");
             assertEquals("sys:store\\" + specialChar + "identifier", searchNode.getName());
         }
+    }
+
+    @Test
+    public void escapeName_dbid() {
+        String unescaped = "sys:node-dbid";
+        String escaped = PropertySearchNode.escapeName(unescaped);
+        assertEquals("dbid not properly escaped", "sys:node\\-dbid", escaped);
+    }
+
+    @Test
+    public void unescapeName_dbid() {
+        String escaped = "sys:node\\-dbid";
+        String unescaped = PropertySearchNode.unescapeName(escaped);
+        assertEquals("dbid not properly unescaped", "sys:node-dbid", unescaped);
+    }
+
+    @Test
+    public void escape_roundtripEquals() {
+        List<String> strings = Arrays.asList("sys:node-dbid", "!@%^&*()-=+[];?,<>|", "nothing:special");
+        List<String> collect = strings.stream()
+                .map(PropertySearchNode::escapeName)
+                .map(PropertySearchNode::unescapeName)
+                .collect(Collectors.toList());
+        assertEquals("Round-trip of escaping and unescaping did not yield initial values", strings, collect);
+
     }
 
 }


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-427
Fixes #42 

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
