### PR TITLE
ALFREDAPI-412 handle null and not authorized cases in getAllNodeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint
 * [ALFREDAPI-422](https://xenitsupport.jira.com/browse/ALFREDAPI-422): Fix totalResults and limits for TDMQ's
 * [ALFREDAPI-427](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Add workaround to prevent Solr Exceptions when searching for numeric values that overflow when parsed as int or long
+* [ALFREDAPI-412](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Fix getAllNodeInfo endpoint to handle null values and non-existing nodes better
 
 ### Deleted
 

--- a/apix-docker/52/debug-extension.docker-compose.yml
+++ b/apix-docker/52/debug-extension.docker-compose.yml
@@ -5,3 +5,11 @@ services:
       - 8000:8000
     environment:
       - DEBUG=true
+      - SHARE_HOST=alfresco-share
+  alfresco-share:
+    image: hub.xenit.eu/alfresco-enterprise/alfresco-share-enterprise:5.2
+    ports:
+      - 8090:8080
+    environment:
+      - DEBUG=true
+      - ALFRESCO_HOST=alfresco-core

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -99,7 +99,7 @@ public class AllNodeInfoTest extends BaseTest {
     }
 
     @Test
-    public void testGetAllNodeInfoWithoutNodeWithoutPermissions() throws IOException {
+    public void testGetAllNodeInfoWithoutNodeWithoutPermissions() throws IOException, JSONException {
         Map<String, NodeRef> initializedNodes = init();
         String jsonString = json("{\"noderefs\":["
                 + "\"" + initializedNodes.get(BaseTest.TESTFILE_NAME).toString() + "\"," //regular node

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.rest.v1.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import eu.xenit.apix.data.NodeRef;
 import java.io.IOException;
@@ -117,6 +118,10 @@ public class AllNodeInfoTest extends BaseTest {
             String responseString = EntityUtils.toString(response.getEntity());
             JSONArray responseJsonArray = new JSONArray(responseString);
             assertEquals(0, responseJsonArray.length());
+        } catch (JSONException jsonException) {
+            String message = "failed to deserialise responsestring";
+            logger.error(message);
+            fail(message);
         }
     }
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -18,7 +18,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +78,45 @@ public class AllNodeInfoTest extends BaseTest {
             String responseString = EntityUtils.toString(response.getEntity());
             JSONArray responseJsonArray = new JSONArray(responseString);
             assertEquals(2, responseJsonArray.length());
+        }
+    }
+
+    @Test
+    public void testGetAllNodeInfoWithNoNodesListed() throws IOException {
+        String jsonString = json("{}");
+
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+        final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v1/nodes/nodeInfo";
+        logger.error("url: " + url);
+        HttpPost httppost = new HttpPost(url);
+        httppost.setEntity(new StringEntity(jsonString));
+
+        try (CloseableHttpResponse response = httpclient.execute(httppost)) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    @Test
+    public void testGetAllNodeInfoForNodeWithoutPermissions() throws IOException {
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url =
+                makeAlfrescoBaseurl(BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS) + "/apix/v1/nodes/nodeInfo";
+        logger.info("url: {}", url);
+        String jsonString = json(
+                "{" +
+                        "\"noderefs\": [\"" +
+                        initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME).toString() +
+                        "\"" +
+                        "]}");
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpPost httppost = new HttpPost(url);
+        httppost.setEntity(new StringEntity(jsonString));
+
+        try (CloseableHttpResponse response = httpclient.execute(httppost)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            String responseString = EntityUtils.toString(response.getEntity());
+            JSONArray responseJsonArray = new JSONArray(responseString);
+            assertEquals(0, responseJsonArray.length());
         }
     }
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
@@ -79,6 +79,45 @@ public class AllNodeInfoTest extends eu.xenit.apix.rest.v2.tests.BaseTest {
         }
     }
 
+    @Test
+    public void testGetAllNodeInfoWithNoNodesListed() throws IOException {
+        String jsonString = json("{}");
+
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+        final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v2/nodes/nodeInfo";
+        logger.error("url: " + url);
+        HttpPost httppost = new HttpPost(url);
+        httppost.setEntity(new StringEntity(jsonString));
+
+        try (CloseableHttpResponse response = httpclient.execute(httppost)) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    @Test
+    public void testGetAllNodeInfoForNodeWithoutPermissions() throws IOException {
+        HashMap<String, NodeRef> initializedNodeRefs = init();
+        String url =
+                makeAlfrescoBaseurl(BaseTest.USERWITHOUTRIGHTS, BaseTest.USERWITHOUTRIGHTS) + "/apix/v2/nodes/nodeInfo";
+        logger.info("url: {}", url);
+        String jsonString = json(
+                "{" +
+                        "\"noderefs\": [\"" +
+                        initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME).toString() +
+                        "\"" +
+                        "]}");
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpPost httppost = new HttpPost(url);
+        httppost.setEntity(new StringEntity(jsonString));
+
+        try (CloseableHttpResponse response = httpclient.execute(httppost)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            String responseString = EntityUtils.toString(response.getEntity());
+            JSONArray responseJsonArray = new JSONArray(responseString);
+            assertEquals(0, responseJsonArray.length());
+        }
+    }
+
     @After
     public void cleanUp() {
         this.removeMainTestFolder();

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
@@ -125,7 +125,7 @@ public class AllNodeInfoTest extends eu.xenit.apix.rest.v2.tests.BaseTest {
     }
 
     @Test
-    public void testGetAllNodeInfoWithoutNodeWithoutPermissions() throws IOException {
+    public void testGetAllNodeInfoWithoutNodeWithoutPermissions() throws IOException, JSONException {
         Map<String, NodeRef> initializedNodes = init();
         String jsonString = json("{\"noderefs\":["
                 + "\"" + initializedNodes.get(eu.xenit.apix.rest.v1.tests.BaseTest.TESTFILE_NAME).toString() + "\"," //regular node

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class AllNodeInfoTest extends eu.xenit.apix.rest.v2.tests.BaseTest {
 
@@ -115,6 +116,10 @@ public class AllNodeInfoTest extends eu.xenit.apix.rest.v2.tests.BaseTest {
             String responseString = EntityUtils.toString(response.getEntity());
             JSONArray responseJsonArray = new JSONArray(responseString);
             assertEquals(0, responseJsonArray.length());
+        } catch (JSONException jsonException) {
+            String message = "failed to deserialise responsestring";
+            logger.error(message);
+            fail(message);
         }
     }
 

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/ApixV1Webscript.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/ApixV1Webscript.java
@@ -104,6 +104,11 @@ public class ApixV1Webscript {
             return null;
         }
 
+        if (!nodeService.exists(nodeRef)) {
+            logger.debug("Excluding node {} from results because it does not exist", nodeRef);
+            return null;
+        }
+
         eu.xenit.apix.filefolder.NodePath path = null;
         if (retrievePath) {
             path = fileFolderService.getPath(nodeRef);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/ApixV2Webscript.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/ApixV2Webscript.java
@@ -44,6 +44,17 @@ public class ApixV2Webscript extends ApixV1Webscript {
             boolean retrieveTargetAssocs, boolean retrieveSourceAssocs) {
         List<NodeInfo> nodeInfoList = new ArrayList<NodeInfo>();
         for (NodeRef nodeRef : nodeRefs) {
+
+            if (!permissionService.hasPermission(nodeRef, IPermissionService.READ)) {
+                logger.warn("Excluding node {} from results due to insufficient permissions", nodeRef);
+                continue;
+            }
+
+            if (!nodeService.exists(nodeRef)) {
+                logger.debug("Excluding node {} from results because it does not exist", nodeRef);
+                continue;
+            }
+
             logger.debug("######################################################");
 
             logger.debug("start getPath");

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
@@ -112,7 +112,11 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
         logger.debug("request content: " + requestString);
         JSONObject jsonObject = new JSONObject(requestString);
         if (jsonObject == null) {
-            throw new NullPointerException("jsonObject is null");
+            response.setStatus(400);
+            String message = String
+                    .format("Malfromed body: request string could not be parsed to jsonObject: %s", requestString);
+            logger.debug(message);
+            writeJsonResponse(response, message);
         }
         logger.debug("json: " + jsonObject.toString());
 
@@ -154,8 +158,10 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
 
             JSONArray nodeRefsJsonArray = jsonObject.getJSONArray("noderefs");
             if (nodeRefsJsonArray == null) {
-                logger.error("noderefsJsonArray is null");
-                throw new NullPointerException("noderefsJsonArray is null");
+                response.setStatus(400);
+                String message = String.format("Could not retrieve target noderefs from body: %s", jsonObject);
+                logger.debug(message);
+                writeJsonResponse(response, message);
             }
             int nodeRefsJsonArrayLength = nodeRefsJsonArray.length();
             logger.debug("nodeRefsJsonArrayLength: " + nodeRefsJsonArrayLength);
@@ -166,8 +172,10 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
                 nodeRefs.add(nodeRef);
             }
         } catch (JSONException e) {
-            e.printStackTrace();
-            return;
+            logger.error("Error deserializing json body", e);
+            String message = String.format("Malformed json body {}", jsonObject);
+            response.setStatus(400);
+            writeJsonResponse(response, message);
         }
 
         logger.debug("done parsing request data");


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-412

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
-> getAllNodeInfo may now return 400 responses instead of unwarranted 500 or faulty 200 responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
