### PR TITLE
ALFREDAPI-365 decrease logging levels to avoid logspam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ALFREDAPI-416](https://xenitsupport.jira.com/browse/ALFREDAPI-416): Removed max repository version from module.properties for builds for most recent Alfresco
 * [ALFREDAPI-420](https://xenitsupport.jira.com/browse/ALFREDAPI-420): Add missing Associations to getAssociations call; `getAssociations` now also returns source associations for a node. `/nodes/nodeInfo` will now also returns source associations by default.
 * [ALFREDAPI-421](https://xenitsupport.jira.com/browse/ALFREDAPI-421): Add 403 Not Authorized responses to `NodesWebscript1.java`
+* [ALFREDAPI-365](https://xenitsupport.jira.com/browse/ALFREDAPI-365): Decrease log levels in `propertyServiceImpl` and `ResourceBundleTranslationKey` to avoid logspam
 
 ### Fixed
 * [ALFREDAPI-419](https://xenitsupport.jira.com/browse/ALFREDAPI-419): Add urldecoding to deleteAssociation endpoint

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/properties/PropertyServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/properties/PropertyServiceImpl.java
@@ -50,7 +50,7 @@ public class PropertyServiceImpl implements IPropertyService {
 
     public eu.xenit.apix.properties.PropertyDefinition GetPropertyDefinition(eu.xenit.apix.data.QName qname) {
         if (!IsValidPropertyQName(qname)) {
-            logger.info("The given property is no valid property: " + qname.toString());
+            logger.debug("The given property is no valid property: " + qname.toString());
             return null;
         }
         PropertyDefinition definition = dictionaryService.getProperty(c.alfresco(qname));

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/translation/ResourceBundleTranslationKey.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/translation/ResourceBundleTranslationKey.java
@@ -120,9 +120,9 @@ public class ResourceBundleTranslationKey {
         try {
             result = QName.createQName(shortQname, namespaceService);
         } catch (InvalidQNameException iqe) {
-            LOGGER.info("Unable to create QName, " + shortQname + " is an invallid qname");
+            LOGGER.debug("Unable to create QName, " + shortQname + " is an invallid qname");
         } catch (NamespaceException ne) {
-            LOGGER.info("Unable to create QName, " + shortQname + " has an invallid namespace");
+            LOGGER.debug("Unable to create QName, " + shortQname + " has an invallid namespace");
         }
 
         return result;


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-365

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
