### PR TITLE
ALFREDAPI-438 Fix AcessDeniedException in getAncestors - change hasReadPermission to hasPermission 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Alfred API - Changelog
 
+## 2.5.1 UNRELEASED
+
+### Fixed
+
+* [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
 
 ## 2.5.0 (2020-07-15)
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -449,7 +449,7 @@ public class NodeService implements INodeService {
         if (!nodeService.exists(nodeRef)) {
             throw new InvalidNodeRefException(String.format(nodeDoesNotExistMesage, nodeRef), nodeRef);
         }
-        if (permissionService.hasReadPermission(nodeRef) != AccessStatus.ALLOWED) {
+        if (permissionService.hasPermission(nodeRef, PermissionService.READ_PERMISSIONS) != AccessStatus.ALLOWED) {
             throw new AccessDeniedException(String.format(accessDeniedMessage, nodeRef));
         }
 
@@ -460,7 +460,7 @@ public class NodeService implements INodeService {
             if (parentRef.equals(alfrescoRootRef)) {
                 break;
             }
-            if (permissionService.hasReadPermission(parentRef) != AccessStatus.ALLOWED) {
+            if (permissionService.hasPermission(parentRef, PermissionService.READ_PERMISSIONS) != AccessStatus.ALLOWED) {
                 throw new AccessDeniedException(String.format(accessDeniedMessage, parentRef));
             }
             ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(parentRef);

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsBaseUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsBaseUnitTest.java
@@ -36,9 +36,9 @@ public abstract class AncestorsBaseUnitTest {
 
     protected PermissionService initPermissionServiceMock() {
         PermissionService permissionServiceMock = mock(PermissionService.class);
-        when(permissionServiceMock.hasReadPermission(eq(testNode1))).thenReturn(AccessStatus.ALLOWED);
-        when(permissionServiceMock.hasReadPermission(eq(testNode2))).thenReturn(AccessStatus.ALLOWED);
-        when(permissionServiceMock.hasReadPermission(eq(testNode3))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode1), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode3), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
 
         return permissionServiceMock;
     }

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromInaccessibleNodeUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromInaccessibleNodeUnitTest.java
@@ -35,7 +35,7 @@ public class AncestorsFromInaccessibleNodeUnitTest extends AncestorsBaseUnitTest
 
     protected PermissionService initPermissionServiceMock() {
         PermissionService permissionServiceMock = super.initPermissionServiceMock();
-        when(permissionServiceMock.hasReadPermission(eq(testNode2)))
+        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS)))
                 .thenReturn(AccessStatus.DENIED);
 
         return permissionServiceMock;

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromNodeUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromNodeUnitTest.java
@@ -48,9 +48,9 @@ public class AncestorsFromNodeUnitTest extends AncestorsBaseUnitTest {
         Assert.assertEquals(2, ancestors.size());
         Assert.assertEquals(testNode2.toString(), ancestors.get(0).toString());
         Assert.assertEquals(testNode3.toString(), ancestors.get(1).toString());
-        verify(alfrescoPermissionService, times(1)).hasReadPermission(eq(testNode1));
-        verify(alfrescoPermissionService, times(1)).hasReadPermission(eq(testNode2));
-        verify(alfrescoPermissionService, times(0)).hasReadPermission(eq(testNode3));
+        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode1), eq(PermissionService.READ_PERMISSIONS));
+        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS));
+        verify(alfrescoPermissionService, times(0)).hasPermission(eq(testNode3), eq(PermissionService.READ_PERMISSIONS));
         verify(alfrescoNodeService, times(1)).exists(eq(testNode1));
         verify(alfrescoNodeService, times(0)).exists(eq(testNode2));
         verify(alfrescoNodeService, times(0)).exists(eq(testNode3));


### PR DESCRIPTION
ALFREDAPI-438 Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException

Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-438

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?
