### PR TITLE
Alfredapi 439 Fixed issue where category facet values would be displayed with their noderef instead of their name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
+* [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
 
 ## 2.5.0 (2020-07-15)
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -97,7 +97,8 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
     }
 
     @Override
-    public void addFacetSearchParameters(SearchQuery.FacetOptions opts, SearchParameters sp, String ftsQuery, SearchSyntaxNode searchNode) {
+    public void addFacetSearchParameters(SearchQuery.FacetOptions opts, SearchParameters sp, String ftsQuery,
+            SearchSyntaxNode searchNode) {
         if (!opts.isEnabled()) {
             return;
         }
@@ -141,13 +142,15 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
                     // For backwards compatability, this is still in use when using the @Deprecated overload
                     // that calls into this method with argument SearchSyntaxNode = null
                     if (searchNode != null) {
-                        List<String> filterQueries = searchNode.accept(new FtsFilterQueryNodeVisitor(fieldFacetQName.toString()));
+                        List<String> filterQueries = searchNode
+                                .accept(new FtsFilterQueryNodeVisitor(fieldFacetQName.toString()));
                         for (String fq : filterQueries) {
                             sp.addFacetQuery(fq);
                         }
                     } else {
                         // @Deprecated AND buggy
-                        String fq = solrFacetHelper.createFacetQueriesFromSearchQuery(fieldFacetQName.toString(), query);
+                        String fq = solrFacetHelper
+                                .createFacetQueriesFromSearchQuery(fieldFacetQName.toString(), query);
                         if (fq != null) {
                             sp.addFacetQuery(fq);
                         }
@@ -306,8 +309,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
         DataTypeDefinition dataType = propertyDefinition.getDataType();
         if (DataTypeDefinition.CATEGORY.equals(dataType.getName())) {
             return new CategoryFacetLabelDisplayHandler(nodeService);
-        }
-        else {
+        } else {
             return ListOfValuesFacetLabelDisplayHandler.createFromProperty(propertyDefinition, dictionaryService);
         }
     }
@@ -365,8 +367,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
                 Serializable nameProperty = nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
                 String name = DefaultTypeConverter.INSTANCE.convert(String.class, nameProperty);
                 return new FacetLabel(value, name, -1);
-            }
-            catch (InvalidNodeRefException ex) {
+            } catch (InvalidNodeRefException ex) {
                 logger.error("Node with node reference {} could not be found", nodeRef);
                 return new FacetLabel(value, value, -1);
             }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -4,12 +4,14 @@ import eu.xenit.apix.search.FacetSearchResult;
 import eu.xenit.apix.search.SearchQuery;
 import eu.xenit.apix.search.nodes.SearchSyntaxNode;
 import eu.xenit.apix.translation.ITranslationService;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.dictionary.constraint.ListOfValuesConstraint;
 import org.alfresco.repo.jscript.ScriptFacetResult;
 import org.alfresco.repo.search.impl.solr.facet.SolrFacetHelper;
@@ -21,9 +23,14 @@ import org.alfresco.repo.search.impl.solr.facet.handler.FacetLabelDisplayHandler
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.dictionary.Constraint;
 import org.alfresco.service.cmr.dictionary.ConstraintDefinition;
+import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.i18n.MessageLookup;
+import org.alfresco.service.cmr.repository.InvalidNodeRefException;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
 import org.alfresco.service.cmr.search.SearchParameters.FieldFacet;
@@ -43,6 +50,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
     private final FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry;
     private SolrFacetHelper solrFacetHelper;
     private DictionaryService dictionaryService;
+    private NodeService nodeService;
     @Autowired
     private SolrFacetService facetService;
     @Autowired
@@ -55,6 +63,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
         facetLabelDisplayHandlerRegistry = serviceRegistry.getFacetLabelDisplayHandlerRegistry();
         solrFacetHelper = serviceRegistry.getSolrFacetHelper();
         dictionaryService = serviceRegistry.getDictionaryService();
+        nodeService = serviceRegistry.getNodeService();
     }
 
     public List<SolrFacetProperties> filterFacets(SearchQuery.FacetOptions opts, List<SolrFacetProperties> facets) {
@@ -211,7 +220,6 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
         }
 
         for (SearchParameters.FieldFacet fieldFacet : fieldFacets) {
-
             // For each requested facet, get the facet results
             List<Pair<String, Integer>> fieldFacetResults = resultSet.getFieldFacet(fieldFacet.getField());
             if (fieldFacetResults == null || fieldFacetResults.size() == 0) {
@@ -274,8 +282,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             if (propertyDefinition == null) {
                 logger.error("Property definition of " + fieldQname + " is null.");
             } else {
-                handler = ListOfValuesFacetLabelDisplayHandler
-                        .createFromProperty(propertyDefinition, dictionaryService);
+                handler = CreateFacetLabelDisplayHandler(propertyDefinition);
             }
         }
         for (Pair<String, Integer> fieldFacetResult : fieldFacetResults) {
@@ -293,6 +300,16 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             response.add(new ScriptFacetResult(facetValue, label, -1, hits));
         }
         return response;
+    }
+
+    private FacetLabelDisplayHandler CreateFacetLabelDisplayHandler(PropertyDefinition propertyDefinition) {
+        DataTypeDefinition dataType = propertyDefinition.getDataType();
+        if (DataTypeDefinition.CATEGORY.equals(dataType.getName())) {
+            return new CategoryFacetLabelDisplayHandler(nodeService);
+        }
+        else {
+            return ListOfValuesFacetLabelDisplayHandler.createFromProperty(propertyDefinition, dictionaryService);
+        }
     }
 
 
@@ -331,5 +348,28 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             return null;
         }
 
+    }
+
+    public static class CategoryFacetLabelDisplayHandler implements FacetLabelDisplayHandler {
+
+        private NodeService nodeService;
+
+        private CategoryFacetLabelDisplayHandler(NodeService nodeService) {
+            this.nodeService = nodeService;
+        }
+
+        @Override
+        public FacetLabel getDisplayLabel(String value) {
+            NodeRef nodeRef = new NodeRef(value);
+            try {
+                Serializable nameProperty = nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
+                String name = DefaultTypeConverter.INSTANCE.convert(String.class, nameProperty);
+                return new FacetLabel(value, name, -1);
+            }
+            catch (InvalidNodeRefException ex) {
+                logger.error("Node with node reference {} could not be found", nodeRef);
+                return new FacetLabel(value, value, -1);
+            }
+        }
     }
 }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -365,6 +365,10 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             NodeRef nodeRef = new NodeRef(value);
             try {
                 Serializable nameProperty = nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
+                if (nameProperty == null) {
+                    return new FacetLabel(value, value, -1);
+                }
+
                 String name = DefaultTypeConverter.INSTANCE.convert(String.class, nameProperty);
                 return new FacetLabel(value, name, -1);
             } catch (InvalidNodeRefException ex) {

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
@@ -23,6 +23,7 @@ import org.alfresco.repo.search.impl.solr.facet.SolrFacetService;
 import org.alfresco.repo.search.impl.solr.facet.handler.FacetLabelDisplayHandlerRegistry;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.dictionary.ConstraintDefinition;
+import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.i18n.MessageLookup;
@@ -54,6 +55,9 @@ public class SearchFacetServiceUnitTest {
         when(serviceRegistryMock.getFacetLabelDisplayHandlerRegistry())
                 .thenReturn(facetLabelDisplayHandlerRegistryStub);
 
+        DataTypeDefinition textDataTypeDef = mock(DataTypeDefinition.class);
+        when(textDataTypeDef.getName()).thenReturn(DataTypeDefinition.TEXT);
+
         DictionaryService dictionaryServiceMock = mock(DictionaryService.class);
 
         QName languageQName = QName.createQName("{http://test.apix.xenit.eu/model/content}language");
@@ -70,6 +74,7 @@ public class SearchFacetServiceUnitTest {
         when(theLanguageConstraintDefinition.getConstraint()).thenReturn(theListOfValuesConstraint);
         languageConstraintDefinitions.add(theLanguageConstraintDefinition);
         when(languagePropDefMock.getConstraints()).thenReturn(languageConstraintDefinitions);
+        when(languagePropDefMock.getDataType()).thenReturn(textDataTypeDef);
         when(dictionaryServiceMock.getProperty(languageQName)).thenReturn(languagePropDefMock);
 
         QName documentStatusQName = QName.createQName("{http://test.apix.xenit.eu/model/content}documentStatus");
@@ -86,6 +91,7 @@ public class SearchFacetServiceUnitTest {
         when(documentStatusConDef.getConstraint()).thenReturn(docStatLOVConstr);
         documnetStatusConDefList.add(documentStatusConDef);
         when(documentStatusPropDefMock.getConstraints()).thenReturn(documnetStatusConDefList);
+        when(documentStatusPropDefMock.getDataType()).thenReturn(textDataTypeDef);
         when(dictionaryServiceMock.getProperty(documentStatusQName)).thenReturn(documentStatusPropDefMock);
 
         when(serviceRegistryMock.getDictionaryService()).thenReturn(dictionaryServiceMock);


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-439

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
