### PR TITLE
Alfredapi 437 paged searches for transactional queries can not fetch more than 1000 results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
 * [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
+* [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
 
 ## 2.5.0 (2020-07-15)
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -15,6 +15,7 @@ import eu.xenit.apix.util.SolrTestHelper;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -23,6 +24,7 @@ import org.alfresco.repo.management.subsystems.SwitchableApplicationContextFacto
 import org.alfresco.repo.model.Repository;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.model.FileInfo;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
@@ -200,6 +202,95 @@ abstract public class SearchServiceTest extends BaseTest {
                         return null;
                     }
                 }, false, true);
+    }
+
+    private boolean alreadyCreated = false;
+    private void createThousandTestDocs() throws InterruptedException {
+        if (alreadyCreated) {
+            System.out.println("1000 test docs already created");
+            return;
+        }
+        System.out.println("Creating 1000 test docs");
+        transactionService.getRetryingTransactionHelper()
+                .doInTransaction((RetryingTransactionCallback<NodeRef>) () -> {
+                    NodeRef companyHomeRef = repository.getCompanyHome();
+
+                    FileInfo mainTestFolder = createMainTestFolder(companyHomeRef);
+                    FileInfo testFolder = createTestFolder(mainTestFolder.getNodeRef(), "testFolderSetOf1000");
+                    Map<QName, Serializable> props = new HashMap<QName, Serializable>() {{
+                        put(ContentModel.PROP_DESCRIPTION, "descriptionSetOf1000");
+                    }};
+                    for (int i = 0; i < 1001 ; i++) {
+                        FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testNode" + i);
+                        nodeService.addProperties(testNode.getNodeRef(), props);
+                    }
+                    return null;
+                }, false, true);
+
+        solrTestHelper.waitForSolrSync();
+        // solrTestHelper has a bug. TODO ticket ALFREDAPI-425
+        Thread.sleep(15000);
+        alreadyCreated = true;
+    }
+
+    @Test
+    public void TestLimitedByMaxPermissionChecks_transactional() throws IOException, InterruptedException {
+        createThousandTestDocs();
+        QueryBuilder builder = new QueryBuilder();
+        SearchSyntaxNode node = builder
+                .property(
+                        ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
+                        "descriptionSetOf1000",
+                        true)
+                .create();
+
+        SearchQuery query = new SearchQuery();
+        query.setQuery(node);
+        query.getPaging().setSkip(800);
+        query.getPaging().setLimit(400);
+        query.setConsistency(SearchQueryConsistency.TRANSACTIONAL);
+        SearchQueryResult result = searchService.query(query);
+        assertEquals(201, result.getNoderefs().size());
+    }
+
+    @Test
+    public void TestLimitedByMaxPermissionChecks_transactional_if_possible() throws IOException, InterruptedException {
+        createThousandTestDocs();
+        QueryBuilder builder = new QueryBuilder();
+        SearchSyntaxNode node = builder
+                .property(
+                        ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
+                        "descriptionSetOf1000",
+                        true)
+                .create();
+
+        SearchQuery query = new SearchQuery();
+        query.setQuery(node);
+        query.getPaging().setSkip(800);
+        query.getPaging().setLimit(400);
+        query.setConsistency(SearchQueryConsistency.TRANSACTIONAL_IF_POSSIBLE);
+        SearchQueryResult result = searchService.query(query);
+        assertEquals(201, result.getNoderefs().size());
+    }
+
+    @Test
+    public void TestLimitedByMaxPermissionChecks_eventual() throws IOException, InterruptedException {
+        createThousandTestDocs();
+        QueryBuilder builder = new QueryBuilder();
+        SearchSyntaxNode node = builder
+                .property(
+                        ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
+                        "descriptionSetOf1000",
+                        true)
+                .create();
+
+        SearchQuery query = new SearchQuery();
+        query.setQuery(node);
+        query.getPaging().setSkip(800);
+        query.getPaging().setLimit(400);
+        query.setConsistency(SearchQueryConsistency.EVENTUAL);
+        SearchQueryResult result = searchService.query(query);
+        assertEquals(201, result.getNoderefs().size());
     }
 
     @Test

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -52,6 +52,7 @@ abstract public class SearchServiceTest extends BaseTest {
 
     private final static Logger logger = LoggerFactory.getLogger(SearchServiceTest.class);
     private static final String ADMIN_USER_NAME = "admin";
+    public static final String DESCRIPTION_SET_OF_1001 = "descriptionSetOf1001";
     @Autowired
     ISearchService searchService;
     @Autowired
@@ -204,24 +205,18 @@ abstract public class SearchServiceTest extends BaseTest {
                 }, false, true);
     }
 
-    private boolean alreadyCreated = false;
-    private void createThousandTestDocs() throws InterruptedException {
-        if (alreadyCreated) {
-            System.out.println("1000 test docs already created");
-            return;
-        }
-        System.out.println("Creating 1000 test docs");
+    private void create1001TestDocs() throws InterruptedException {
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction((RetryingTransactionCallback<NodeRef>) () -> {
                     NodeRef companyHomeRef = repository.getCompanyHome();
 
                     FileInfo mainTestFolder = createMainTestFolder(companyHomeRef);
-                    FileInfo testFolder = createTestFolder(mainTestFolder.getNodeRef(), "testFolderSetOf1000");
+                    FileInfo testFolder = createTestFolder(mainTestFolder.getNodeRef(), "testFolderSetOf1001");
                     Map<QName, Serializable> props = new HashMap<QName, Serializable>() {{
-                        put(ContentModel.PROP_DESCRIPTION, "descriptionSetOf1000");
+                        put(ContentModel.PROP_DESCRIPTION, DESCRIPTION_SET_OF_1001);
                     }};
                     for (int i = 0; i < 1001 ; i++) {
-                        FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testNode" + i);
+                        FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testNode-1001-" + i);
                         nodeService.addProperties(testNode.getNodeRef(), props);
                     }
                     return null;
@@ -230,17 +225,16 @@ abstract public class SearchServiceTest extends BaseTest {
         solrTestHelper.waitForSolrSync();
         // solrTestHelper has a bug. TODO ticket ALFREDAPI-425
         Thread.sleep(15000);
-        alreadyCreated = true;
     }
 
     @Test
-    public void TestLimitedByMaxPermissionChecks_transactional() throws IOException, InterruptedException {
-        createThousandTestDocs();
+    public void TestLimitedByMaxPermissionChecks_transactional() throws InterruptedException {
+        create1001TestDocs();
         QueryBuilder builder = new QueryBuilder();
         SearchSyntaxNode node = builder
                 .property(
                         ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
-                        "descriptionSetOf1000",
+                        DESCRIPTION_SET_OF_1001,
                         true)
                 .create();
 
@@ -254,13 +248,13 @@ abstract public class SearchServiceTest extends BaseTest {
     }
 
     @Test
-    public void TestLimitedByMaxPermissionChecks_transactional_if_possible() throws IOException, InterruptedException {
-        createThousandTestDocs();
+    public void TestLimitedByMaxPermissionChecks_transactional_if_possible() throws InterruptedException {
+        create1001TestDocs();
         QueryBuilder builder = new QueryBuilder();
         SearchSyntaxNode node = builder
                 .property(
                         ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
-                        "descriptionSetOf1000",
+                        DESCRIPTION_SET_OF_1001,
                         true)
                 .create();
 
@@ -274,13 +268,13 @@ abstract public class SearchServiceTest extends BaseTest {
     }
 
     @Test
-    public void TestLimitedByMaxPermissionChecks_eventual() throws IOException, InterruptedException {
-        createThousandTestDocs();
+    public void TestLimitedByMaxPermissionChecks_eventual() throws InterruptedException {
+        create1001TestDocs();
         QueryBuilder builder = new QueryBuilder();
         SearchSyntaxNode node = builder
                 .property(
                         ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
-                        "descriptionSetOf1000",
+                        DESCRIPTION_SET_OF_1001,
                         true)
                 .create();
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
@@ -101,8 +101,10 @@ public class SearchService implements ISearchService {
         searchParameters.setLanguage(org.alfresco.service.cmr.search.SearchService.LANGUAGE_FTS_ALFRESCO);
         if (postQuery.getConsistency() == SearchQueryConsistency.TRANSACTIONAL) {
             searchParameters.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
+            searchParameters.setMaxPermissionChecks(Integer.MAX_VALUE);
         } else if (postQuery.getConsistency() == SearchQueryConsistency.TRANSACTIONAL_IF_POSSIBLE) {
             searchParameters.setQueryConsistency(QueryConsistency.TRANSACTIONAL_IF_POSSIBLE);
+            searchParameters.setMaxPermissionChecks(Integer.MAX_VALUE);
         } else if (postQuery.getConsistency() == SearchQueryConsistency.EVENTUAL) {
             searchParameters.setQueryConsistency(QueryConsistency.EVENTUAL);
         } else {


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-437

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.


~~I'm looking to improve the test performance a bit before getting this merged.~~
~~I'm opening the PR already for remarks beside test performance.~~

Fixing the `@Before` logic considering integration tests is out of scope
Integration tests introduced here are just going to be slow