### PR TITLE
ALFREDAPI-440 Release v2.5.1 (2nd attempt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
 * [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
+* [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
 
 ## 2.5.0 (2020-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Alfred API - Changelog
 
+## 2.5.1 UNRELEASED
+
+### Fixed
+* [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
+* [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
 
 ## 2.5.0 (2020-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Alfred API - Changelog
 
-## 2.5.1 UNRELEASED
+## 2.5.1 (2020-08-05)
 
 ### Fixed
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
@@ -24,9 +24,6 @@
 * [ALFREDAPI-427](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Add workaround to prevent Solr Exceptions when searching for numeric values that overflow when parsed as int or long
 * [ALFREDAPI-412](https://xenitsupport.jira.com/browse/ALFREDAPI-427): Fix getAllNodeInfo endpoint to handle null values and non-existing nodes better
 * [ALFREDAPI-388](https://xenitsupport.jira.com/browse/ALFREDAPI-388): Add handling for preexisting file in upload
-
-### Deleted
-
 
 
 ## 2.4.0 (2020-03-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
 * [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
 
+
 ## 2.5.0 (2020-07-15)
 
 ### Added

--- a/apix-docker/50/build.gradle
+++ b/apix-docker/50/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.0.4@war"
+    if (!ci.isCi()) {
+        alfrescoAmp(group: 'eu.xenit.care4alf', name: 'care4alf-5x', version: "${care4alfVersion}", ext: 'amp')
+    }
 }
 
 dockerAlfresco {

--- a/apix-docker/50/debug-extension.docker-compose.yml
+++ b/apix-docker/50/debug-extension.docker-compose.yml
@@ -5,3 +5,11 @@ services:
       - 8000:8000
     environment:
       - DEBUG=true
+      - SHARE_HOST=alfresco-share
+  alfresco-share:
+    image: hub.xenit.eu/alfresco-enterprise/alfresco-share-enterprise:5.0
+    ports:
+      - 8090:8080
+    environment:
+      - DEBUG=true
+      - ALFRESCO_HOST=alfresco-core

--- a/apix-docker/51/build.gradle
+++ b/apix-docker/51/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.1.5@war"
+    if (!ci.isCi()) {
+        alfrescoAmp(group: 'eu.xenit.care4alf', name: 'care4alf-5x', version: "${care4alfVersion}", ext: 'amp')
+    }
 }
 
 dockerAlfresco {

--- a/apix-docker/51/debug-extension.docker-compose.yml
+++ b/apix-docker/51/debug-extension.docker-compose.yml
@@ -5,3 +5,11 @@ services:
       - 8000:8000
     environment:
       - DEBUG=true
+      - SHARE_HOST=alfresco-share
+  alfresco-share:
+    image: hub.xenit.eu/alfresco-enterprise/alfresco-share-enterprise:5.1
+    ports:
+      - 8090:8080
+    environment:
+      - DEBUG=true
+      - ALFRESCO_HOST=alfresco-core

--- a/apix-docker/52/build.gradle
+++ b/apix-docker/52/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.2.5@war"
+    if (!ci.isCi()) {
+        alfrescoAmp(group: 'eu.xenit.care4alf', name: 'care4alf-5x', version: "${care4alfVersion}", ext: 'amp')
+    }
 }
 
 dockerAlfresco {

--- a/apix-docker/60/build.gradle
+++ b/apix-docker/60/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
     baseAlfrescoWar "org.alfresco:content-services:6.0.1.2@war"
+    if (!ci.isCi()) {
+        alfrescoAmp(group: 'eu.xenit.care4alf', name: 'care4alf-6x', version: "${care4alfVersion}", ext: 'amp')
+    }
 }
 
 dockerAlfresco {

--- a/apix-docker/60/debug-extension.docker-compose.yml
+++ b/apix-docker/60/debug-extension.docker-compose.yml
@@ -5,3 +5,11 @@ services:
       - 8000:8000
     environment:
       - DEBUG=true
+      - SHARE_HOST=alfresco-share
+  alfresco-share:
+    image: hub.xenit.eu/public/alfresco-share-community:6.0
+    ports:
+      - 8090:8080
+    environment:
+      - DEBUG=true
+      - ALFRESCO_HOST=alfresco-core

--- a/apix-docker/61/build.gradle
+++ b/apix-docker/61/build.gradle
@@ -2,6 +2,9 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:content-services:6.1.1@war'
     // Fix for https://github.com/xenit-eu/dynamic-extensions-for-alfresco#alfresco-61---wrong-version-of-commons-annotations-used
     alfrescoAmp(group: 'eu.xenit.alfresco', name: 'alfresco-hotfix-MNT-20557', version: '1.0.1', ext: 'amp')
+    if (!ci.isCi()) {
+        alfrescoAmp(group: 'eu.xenit.care4alf', name: 'care4alf-6x', version: "${care4alfVersion}", ext: 'amp')
+    }
 }
 
 dockerAlfresco {

--- a/apix-docker/61/debug-extension.docker-compose.yml
+++ b/apix-docker/61/debug-extension.docker-compose.yml
@@ -5,3 +5,11 @@ services:
       - 8000:8000
     environment:
       - DEBUG=true
+      - SHARE_HOST=alfresco-share
+  alfresco-share:
+    image: alfresco/alfresco-share:6.1.1
+    ports:
+      - 8090:8080
+    environment:
+      - DEBUG=true
+      - ALFRESCO_HOST=alfresco-core

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -15,6 +15,7 @@ import eu.xenit.apix.util.SolrTestHelper;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -23,6 +24,7 @@ import org.alfresco.repo.management.subsystems.SwitchableApplicationContextFacto
 import org.alfresco.repo.model.Repository;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.model.FileInfo;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
@@ -200,6 +202,95 @@ abstract public class SearchServiceTest extends BaseTest {
                         return null;
                     }
                 }, false, true);
+    }
+
+    private boolean alreadyCreated = false;
+    private void createThousandTestDocs() throws InterruptedException {
+        if (alreadyCreated) {
+            System.out.println("1000 test docs already created");
+            return;
+        }
+        System.out.println("Creating 1000 test docs");
+        transactionService.getRetryingTransactionHelper()
+                .doInTransaction((RetryingTransactionCallback<NodeRef>) () -> {
+                    NodeRef companyHomeRef = repository.getCompanyHome();
+
+                    FileInfo mainTestFolder = createMainTestFolder(companyHomeRef);
+                    FileInfo testFolder = createTestFolder(mainTestFolder.getNodeRef(), "testFolderSetOf1000");
+                    Map<QName, Serializable> props = new HashMap<QName, Serializable>() {{
+                        put(ContentModel.PROP_DESCRIPTION, "descriptionSetOf1000");
+                    }};
+                    for (int i = 0; i < 1001 ; i++) {
+                        FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testNode" + i);
+                        nodeService.addProperties(testNode.getNodeRef(), props);
+                    }
+                    return null;
+                }, false, true);
+
+        solrTestHelper.waitForSolrSync();
+        // solrTestHelper has a bug. TODO ticket ALFREDAPI-425
+        Thread.sleep(15000);
+        alreadyCreated = true;
+    }
+
+    @Test
+    public void TestLimitedByMaxPermissionChecks_transactional() throws IOException, InterruptedException {
+        createThousandTestDocs();
+        QueryBuilder builder = new QueryBuilder();
+        SearchSyntaxNode node = builder
+                .property(
+                        ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
+                        "descriptionSetOf1000",
+                        true)
+                .create();
+
+        SearchQuery query = new SearchQuery();
+        query.setQuery(node);
+        query.getPaging().setSkip(800);
+        query.getPaging().setLimit(400);
+        query.setConsistency(SearchQueryConsistency.TRANSACTIONAL);
+        SearchQueryResult result = searchService.query(query);
+        assertEquals(201, result.getNoderefs().size());
+    }
+
+    @Test
+    public void TestLimitedByMaxPermissionChecks_transactional_if_possible() throws IOException, InterruptedException {
+        createThousandTestDocs();
+        QueryBuilder builder = new QueryBuilder();
+        SearchSyntaxNode node = builder
+                .property(
+                        ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
+                        "descriptionSetOf1000",
+                        true)
+                .create();
+
+        SearchQuery query = new SearchQuery();
+        query.setQuery(node);
+        query.getPaging().setSkip(800);
+        query.getPaging().setLimit(400);
+        query.setConsistency(SearchQueryConsistency.TRANSACTIONAL_IF_POSSIBLE);
+        SearchQueryResult result = searchService.query(query);
+        assertEquals(201, result.getNoderefs().size());
+    }
+
+    @Test
+    public void TestLimitedByMaxPermissionChecks_eventual() throws IOException, InterruptedException {
+        createThousandTestDocs();
+        QueryBuilder builder = new QueryBuilder();
+        SearchSyntaxNode node = builder
+                .property(
+                        ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
+                        "descriptionSetOf1000",
+                        true)
+                .create();
+
+        SearchQuery query = new SearchQuery();
+        query.setQuery(node);
+        query.getPaging().setSkip(800);
+        query.getPaging().setLimit(400);
+        query.setConsistency(SearchQueryConsistency.EVENTUAL);
+        SearchQueryResult result = searchService.query(query);
+        assertEquals(201, result.getNoderefs().size());
     }
 
     @Test

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -52,6 +52,7 @@ abstract public class SearchServiceTest extends BaseTest {
 
     private final static Logger logger = LoggerFactory.getLogger(SearchServiceTest.class);
     private static final String ADMIN_USER_NAME = "admin";
+    public static final String DESCRIPTION_SET_OF_1001 = "descriptionSetOf1001";
     @Autowired
     ISearchService searchService;
     @Autowired
@@ -204,24 +205,18 @@ abstract public class SearchServiceTest extends BaseTest {
                 }, false, true);
     }
 
-    private boolean alreadyCreated = false;
-    private void createThousandTestDocs() throws InterruptedException {
-        if (alreadyCreated) {
-            System.out.println("1000 test docs already created");
-            return;
-        }
-        System.out.println("Creating 1000 test docs");
+    private void create1001TestDocs() throws InterruptedException {
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction((RetryingTransactionCallback<NodeRef>) () -> {
                     NodeRef companyHomeRef = repository.getCompanyHome();
 
                     FileInfo mainTestFolder = createMainTestFolder(companyHomeRef);
-                    FileInfo testFolder = createTestFolder(mainTestFolder.getNodeRef(), "testFolderSetOf1000");
+                    FileInfo testFolder = createTestFolder(mainTestFolder.getNodeRef(), "testFolderSetOf1001");
                     Map<QName, Serializable> props = new HashMap<QName, Serializable>() {{
-                        put(ContentModel.PROP_DESCRIPTION, "descriptionSetOf1000");
+                        put(ContentModel.PROP_DESCRIPTION, DESCRIPTION_SET_OF_1001);
                     }};
                     for (int i = 0; i < 1001 ; i++) {
-                        FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testNode" + i);
+                        FileInfo testNode = createTestNode(testFolder.getNodeRef(), "testNode-1001-" + i);
                         nodeService.addProperties(testNode.getNodeRef(), props);
                     }
                     return null;
@@ -230,17 +225,16 @@ abstract public class SearchServiceTest extends BaseTest {
         solrTestHelper.waitForSolrSync();
         // solrTestHelper has a bug. TODO ticket ALFREDAPI-425
         Thread.sleep(15000);
-        alreadyCreated = true;
     }
 
     @Test
-    public void TestLimitedByMaxPermissionChecks_transactional() throws IOException, InterruptedException {
-        createThousandTestDocs();
+    public void TestLimitedByMaxPermissionChecks_transactional() throws InterruptedException {
+        create1001TestDocs();
         QueryBuilder builder = new QueryBuilder();
         SearchSyntaxNode node = builder
                 .property(
                         ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
-                        "descriptionSetOf1000",
+                        DESCRIPTION_SET_OF_1001,
                         true)
                 .create();
 
@@ -254,13 +248,13 @@ abstract public class SearchServiceTest extends BaseTest {
     }
 
     @Test
-    public void TestLimitedByMaxPermissionChecks_transactional_if_possible() throws IOException, InterruptedException {
-        createThousandTestDocs();
+    public void TestLimitedByMaxPermissionChecks_transactional_if_possible() throws InterruptedException {
+        create1001TestDocs();
         QueryBuilder builder = new QueryBuilder();
         SearchSyntaxNode node = builder
                 .property(
                         ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
-                        "descriptionSetOf1000",
+                        DESCRIPTION_SET_OF_1001,
                         true)
                 .create();
 
@@ -274,13 +268,13 @@ abstract public class SearchServiceTest extends BaseTest {
     }
 
     @Test
-    public void TestLimitedByMaxPermissionChecks_eventual() throws IOException, InterruptedException {
-        createThousandTestDocs();
+    public void TestLimitedByMaxPermissionChecks_eventual() throws InterruptedException {
+        create1001TestDocs();
         QueryBuilder builder = new QueryBuilder();
         SearchSyntaxNode node = builder
                 .property(
                         ContentModel.PROP_DESCRIPTION.toPrefixString(namespacePrefixResolver),
-                        "descriptionSetOf1000",
+                        DESCRIPTION_SET_OF_1001,
                         true)
                 .create();
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -449,7 +449,7 @@ public class NodeService implements INodeService {
         if (!nodeService.exists(nodeRef)) {
             throw new InvalidNodeRefException(String.format(nodeDoesNotExistMesage, nodeRef), nodeRef);
         }
-        if (permissionService.hasReadPermission(nodeRef) != AccessStatus.ALLOWED) {
+        if (permissionService.hasPermission(nodeRef, PermissionService.READ_PERMISSIONS) != AccessStatus.ALLOWED) {
             throw new AccessDeniedException(String.format(accessDeniedMessage, nodeRef));
         }
 
@@ -460,7 +460,7 @@ public class NodeService implements INodeService {
             if (parentRef.equals(alfrescoRootRef)) {
                 break;
             }
-            if (permissionService.hasReadPermission(parentRef) != AccessStatus.ALLOWED) {
+            if (permissionService.hasPermission(parentRef, PermissionService.READ_PERMISSIONS) != AccessStatus.ALLOWED) {
                 throw new AccessDeniedException(String.format(accessDeniedMessage, parentRef));
             }
             ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(parentRef);

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -97,7 +97,8 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
     }
 
     @Override
-    public void addFacetSearchParameters(SearchQuery.FacetOptions opts, SearchParameters sp, String ftsQuery, SearchSyntaxNode searchNode) {
+    public void addFacetSearchParameters(SearchQuery.FacetOptions opts, SearchParameters sp, String ftsQuery,
+            SearchSyntaxNode searchNode) {
         if (!opts.isEnabled()) {
             return;
         }
@@ -141,13 +142,15 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
                     // For backwards compatability, this is still in use when using the @Deprecated overload
                     // that calls into this method with argument SearchSyntaxNode = null
                     if (searchNode != null) {
-                        List<String> filterQueries = searchNode.accept(new FtsFilterQueryNodeVisitor(fieldFacetQName.toString()));
+                        List<String> filterQueries = searchNode
+                                .accept(new FtsFilterQueryNodeVisitor(fieldFacetQName.toString()));
                         for (String fq : filterQueries) {
                             sp.addFacetQuery(fq);
                         }
                     } else {
                         // @Deprecated AND buggy
-                        String fq = solrFacetHelper.createFacetQueriesFromSearchQuery(fieldFacetQName.toString(), query);
+                        String fq = solrFacetHelper
+                                .createFacetQueriesFromSearchQuery(fieldFacetQName.toString(), query);
                         if (fq != null) {
                             sp.addFacetQuery(fq);
                         }
@@ -306,8 +309,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
         DataTypeDefinition dataType = propertyDefinition.getDataType();
         if (DataTypeDefinition.CATEGORY.equals(dataType.getName())) {
             return new CategoryFacetLabelDisplayHandler(nodeService);
-        }
-        else {
+        } else {
             return ListOfValuesFacetLabelDisplayHandler.createFromProperty(propertyDefinition, dictionaryService);
         }
     }
@@ -365,8 +367,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
                 Serializable nameProperty = nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
                 String name = DefaultTypeConverter.INSTANCE.convert(String.class, nameProperty);
                 return new FacetLabel(value, name, -1);
-            }
-            catch (InvalidNodeRefException ex) {
+            } catch (InvalidNodeRefException ex) {
                 logger.error("Node with node reference {} could not be found", nodeRef);
                 return new FacetLabel(value, value, -1);
             }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -4,12 +4,14 @@ import eu.xenit.apix.search.FacetSearchResult;
 import eu.xenit.apix.search.SearchQuery;
 import eu.xenit.apix.search.nodes.SearchSyntaxNode;
 import eu.xenit.apix.translation.ITranslationService;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.dictionary.constraint.ListOfValuesConstraint;
 import org.alfresco.repo.jscript.ScriptFacetResult;
 import org.alfresco.repo.search.impl.solr.facet.SolrFacetHelper;
@@ -21,9 +23,14 @@ import org.alfresco.repo.search.impl.solr.facet.handler.FacetLabelDisplayHandler
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.dictionary.Constraint;
 import org.alfresco.service.cmr.dictionary.ConstraintDefinition;
+import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.i18n.MessageLookup;
+import org.alfresco.service.cmr.repository.InvalidNodeRefException;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
 import org.alfresco.service.cmr.search.SearchParameters.FieldFacet;
@@ -43,6 +50,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
     private final FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry;
     private SolrFacetHelper solrFacetHelper;
     private DictionaryService dictionaryService;
+    private NodeService nodeService;
     @Autowired
     private SolrFacetService facetService;
     @Autowired
@@ -55,6 +63,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
         facetLabelDisplayHandlerRegistry = serviceRegistry.getFacetLabelDisplayHandlerRegistry();
         solrFacetHelper = serviceRegistry.getSolrFacetHelper();
         dictionaryService = serviceRegistry.getDictionaryService();
+        nodeService = serviceRegistry.getNodeService();
     }
 
     public List<SolrFacetProperties> filterFacets(SearchQuery.FacetOptions opts, List<SolrFacetProperties> facets) {
@@ -211,7 +220,6 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
         }
 
         for (SearchParameters.FieldFacet fieldFacet : fieldFacets) {
-
             // For each requested facet, get the facet results
             List<Pair<String, Integer>> fieldFacetResults = resultSet.getFieldFacet(fieldFacet.getField());
             if (fieldFacetResults == null || fieldFacetResults.size() == 0) {
@@ -274,8 +282,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             if (propertyDefinition == null) {
                 logger.error("Property definition of " + fieldQname + " is null.");
             } else {
-                handler = ListOfValuesFacetLabelDisplayHandler
-                        .createFromProperty(propertyDefinition, dictionaryService);
+                handler = CreateFacetLabelDisplayHandler(propertyDefinition);
             }
         }
         for (Pair<String, Integer> fieldFacetResult : fieldFacetResults) {
@@ -293,6 +300,16 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             response.add(new ScriptFacetResult(facetValue, label, -1, hits));
         }
         return response;
+    }
+
+    private FacetLabelDisplayHandler CreateFacetLabelDisplayHandler(PropertyDefinition propertyDefinition) {
+        DataTypeDefinition dataType = propertyDefinition.getDataType();
+        if (DataTypeDefinition.CATEGORY.equals(dataType.getName())) {
+            return new CategoryFacetLabelDisplayHandler(nodeService);
+        }
+        else {
+            return ListOfValuesFacetLabelDisplayHandler.createFromProperty(propertyDefinition, dictionaryService);
+        }
     }
 
 
@@ -331,5 +348,28 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             return null;
         }
 
+    }
+
+    public static class CategoryFacetLabelDisplayHandler implements FacetLabelDisplayHandler {
+
+        private NodeService nodeService;
+
+        private CategoryFacetLabelDisplayHandler(NodeService nodeService) {
+            this.nodeService = nodeService;
+        }
+
+        @Override
+        public FacetLabel getDisplayLabel(String value) {
+            NodeRef nodeRef = new NodeRef(value);
+            try {
+                Serializable nameProperty = nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
+                String name = DefaultTypeConverter.INSTANCE.convert(String.class, nameProperty);
+                return new FacetLabel(value, name, -1);
+            }
+            catch (InvalidNodeRefException ex) {
+                logger.error("Node with node reference {} could not be found", nodeRef);
+                return new FacetLabel(value, value, -1);
+            }
+        }
     }
 }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -365,6 +365,10 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             NodeRef nodeRef = new NodeRef(value);
             try {
                 Serializable nameProperty = nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
+                if (nameProperty == null) {
+                    return new FacetLabel(value, value, -1);
+                }
+
                 String name = DefaultTypeConverter.INSTANCE.convert(String.class, nameProperty);
                 return new FacetLabel(value, name, -1);
             } catch (InvalidNodeRefException ex) {

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchService.java
@@ -101,8 +101,10 @@ public class SearchService implements ISearchService {
         searchParameters.setLanguage(org.alfresco.service.cmr.search.SearchService.LANGUAGE_FTS_ALFRESCO);
         if (postQuery.getConsistency() == SearchQueryConsistency.TRANSACTIONAL) {
             searchParameters.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
+            searchParameters.setMaxPermissionChecks(Integer.MAX_VALUE);
         } else if (postQuery.getConsistency() == SearchQueryConsistency.TRANSACTIONAL_IF_POSSIBLE) {
             searchParameters.setQueryConsistency(QueryConsistency.TRANSACTIONAL_IF_POSSIBLE);
+            searchParameters.setMaxPermissionChecks(Integer.MAX_VALUE);
         } else if (postQuery.getConsistency() == SearchQueryConsistency.EVENTUAL) {
             searchParameters.setQueryConsistency(QueryConsistency.EVENTUAL);
         } else {

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsBaseUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsBaseUnitTest.java
@@ -36,9 +36,9 @@ public abstract class AncestorsBaseUnitTest {
 
     protected PermissionService initPermissionServiceMock() {
         PermissionService permissionServiceMock = mock(PermissionService.class);
-        when(permissionServiceMock.hasReadPermission(eq(testNode1))).thenReturn(AccessStatus.ALLOWED);
-        when(permissionServiceMock.hasReadPermission(eq(testNode2))).thenReturn(AccessStatus.ALLOWED);
-        when(permissionServiceMock.hasReadPermission(eq(testNode3))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode1), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode3), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
 
         return permissionServiceMock;
     }

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromInaccessibleNodeUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromInaccessibleNodeUnitTest.java
@@ -35,7 +35,7 @@ public class AncestorsFromInaccessibleNodeUnitTest extends AncestorsBaseUnitTest
 
     protected PermissionService initPermissionServiceMock() {
         PermissionService permissionServiceMock = super.initPermissionServiceMock();
-        when(permissionServiceMock.hasReadPermission(eq(testNode2)))
+        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS)))
                 .thenReturn(AccessStatus.DENIED);
 
         return permissionServiceMock;

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromNodeUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromNodeUnitTest.java
@@ -48,9 +48,9 @@ public class AncestorsFromNodeUnitTest extends AncestorsBaseUnitTest {
         Assert.assertEquals(2, ancestors.size());
         Assert.assertEquals(testNode2.toString(), ancestors.get(0).toString());
         Assert.assertEquals(testNode3.toString(), ancestors.get(1).toString());
-        verify(alfrescoPermissionService, times(1)).hasReadPermission(eq(testNode1));
-        verify(alfrescoPermissionService, times(1)).hasReadPermission(eq(testNode2));
-        verify(alfrescoPermissionService, times(0)).hasReadPermission(eq(testNode3));
+        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode1), eq(PermissionService.READ_PERMISSIONS));
+        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS));
+        verify(alfrescoPermissionService, times(0)).hasPermission(eq(testNode3), eq(PermissionService.READ_PERMISSIONS));
         verify(alfrescoNodeService, times(1)).exists(eq(testNode1));
         verify(alfrescoNodeService, times(0)).exists(eq(testNode2));
         verify(alfrescoNodeService, times(0)).exists(eq(testNode3));

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
@@ -23,6 +23,7 @@ import org.alfresco.repo.search.impl.solr.facet.SolrFacetService;
 import org.alfresco.repo.search.impl.solr.facet.handler.FacetLabelDisplayHandlerRegistry;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.dictionary.ConstraintDefinition;
+import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.i18n.MessageLookup;
@@ -54,6 +55,9 @@ public class SearchFacetServiceUnitTest {
         when(serviceRegistryMock.getFacetLabelDisplayHandlerRegistry())
                 .thenReturn(facetLabelDisplayHandlerRegistryStub);
 
+        DataTypeDefinition textDataTypeDef = mock(DataTypeDefinition.class);
+        when(textDataTypeDef.getName()).thenReturn(DataTypeDefinition.TEXT);
+
         DictionaryService dictionaryServiceMock = mock(DictionaryService.class);
 
         QName languageQName = QName.createQName("{http://test.apix.xenit.eu/model/content}language");
@@ -70,6 +74,7 @@ public class SearchFacetServiceUnitTest {
         when(theLanguageConstraintDefinition.getConstraint()).thenReturn(theListOfValuesConstraint);
         languageConstraintDefinitions.add(theLanguageConstraintDefinition);
         when(languagePropDefMock.getConstraints()).thenReturn(languageConstraintDefinitions);
+        when(languagePropDefMock.getDataType()).thenReturn(textDataTypeDef);
         when(dictionaryServiceMock.getProperty(languageQName)).thenReturn(languagePropDefMock);
 
         QName documentStatusQName = QName.createQName("{http://test.apix.xenit.eu/model/content}documentStatus");
@@ -86,6 +91,7 @@ public class SearchFacetServiceUnitTest {
         when(documentStatusConDef.getConstraint()).thenReturn(docStatLOVConstr);
         documnetStatusConDefList.add(documentStatusConDef);
         when(documentStatusPropDefMock.getConstraints()).thenReturn(documnetStatusConDefList);
+        when(documentStatusPropDefMock.getDataType()).thenReturn(textDataTypeDef);
         when(dictionaryServiceMock.getProperty(documentStatusQName)).thenReturn(documentStatusPropDefMock);
 
         when(serviceRegistryMock.getDictionaryService()).thenReturn(dictionaryServiceMock);

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
 }
 
 ext {
-    versionWithoutQualifier = '2.5.0'
+    versionWithoutQualifier = '2.5.1'
 
     jackson_version = '2.6.3'
     swagger_version = "1.5.7"

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ ext {
     alfresco_52_dm_version = "6.16"
     alfresco_60_dm_version = "8.9"
     alfresco_61_dm_version = "8.25.1"
+    
+    care4alfVersion = '2.3.0'
 }
 
 subprojects {


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-440

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
