### PR TITLE
ALFREDAPI-440 Release 2.5.1 - post release commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,27 @@
 # Alfred API - Changelog
 
-## 2.5.1 (2020-08-05)
+## 2.5.2 UNRELEASED
+
+### Added
+
+
+## Changed
+
 
 ### Fixed
 
+
+### Deleted
+
+
+
+## 2.5.1 (2020-08-05)
+
+### Fixed
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
 * [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
 * [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
+
 
 ## 2.5.0 (2020-07-15)
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
 }
 
 ext {
-    versionWithoutQualifier = '2.5.1'
+    versionWithoutQualifier = '2.5.2'
 
     jackson_version = '2.6.3'
     swagger_version = "1.5.7"


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-440

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
