### PR TITLE
ALFREDAPI-338 Changed CopyFrom behaviour to also set the provided properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 * [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
 * [ALFREDAPI-338](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue when the provided name would not be set while copying a node 
 
->>>>>>> ALFREDAPI-338 Changed CopyFrom behaviour to also set the provide properties in the request
 ## 2.5.0 (2020-07-15)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
 * [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
 * [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
+* [ALFREDAPI-338](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue when the provided name would not be set while copying a node 
 
-
+>>>>>>> ALFREDAPI-338 Changed CopyFrom behaviour to also set the provide properties in the request
 ## 2.5.0 (2020-07-15)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 
 ### Fixed
+* [ALFREDAPI-338](https://xenitsupport.jira.com/browse/ALFREDAPI-338): Fixed issue when the provided name would not be set while copying a node 
 
 
 ### Deleted
@@ -21,7 +22,6 @@
 * [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Replace hasReadPermission with hasPermission to avoid an Alfresco bug that prevents usage of that method and throws AcessDeniedException
 * [ALFREDAPI-439](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue where category facet values would be displayed with their noderef instead of their name
 * [ALFREDAPI-437](https://xenitsupport.jira.com/browse/ALFREDAPI-437): Fixed issue where paged searches for transactional queries could not fetch more than 1000 results
-* [ALFREDAPI-338](https://xenitsupport.jira.com/browse/ALFREDAPI-439): Fixed issue when the provided name would not be set while copying a node 
 
 ## 2.5.0 (2020-07-15)
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
@@ -57,7 +57,7 @@ public class CopyNodeTest extends BaseTest {
 
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(() -> {
-                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.TESTFILE_NAME).toString(), 200);
+                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.TESTFILE_NAME).toString(),200);
                     return null;
                 }, false, true);
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
@@ -1,19 +1,25 @@
 package eu.xenit.apix.rest.v1.tests;
 
 import eu.xenit.apix.data.NodeRef;
+import eu.xenit.apix.data.QName;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.node.NodeAssociation;
 import eu.xenit.apix.node.ChildParentAssociation;
 import java.util.HashMap;
+
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
-import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.transaction.TransactionService;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +29,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import java.util.List;
+import java.util.Map;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -40,6 +48,7 @@ public class CopyNodeTest extends BaseTest {
     @Qualifier("TransactionService")
     TransactionService transactionService;
 
+
     @Before
     public void setup() {
         AuthenticationUtil.setAdminUserAsFullyAuthenticatedUser();
@@ -52,17 +61,47 @@ public class CopyNodeTest extends BaseTest {
         final ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
         final NodeRef parentRef = primaryParentAssoc.getTarget();
 
-        final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v1/nodes";
+        final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v2/nodes";
         final CloseableHttpClient httpclient = HttpClients.createDefault();
 
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(() -> {
-                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.TESTFILE_NAME).toString(),200);
+                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.TESTFILE_NAME).toString(),null, null, 200);
                     return null;
                 }, false, true);
 
         List<ChildParentAssociation> newChildAssocs = nodeService.getChildAssociations(parentRef);
         assertEquals(2, newChildAssocs.size());
+    }
+
+    @Test
+    public void testCopyNodeWithProperties() throws Throwable {
+        final HashMap<String, NodeRef> initializedNodeRefs = init();
+        List<ChildParentAssociation> parentAssociations = this.nodeService.getParentAssociations(initializedNodeRefs.get(BaseTest.TESTFILE_NAME));
+        final ChildParentAssociation primaryParentAssoc = (ChildParentAssociation) parentAssociations.get(0);
+        final NodeRef parentRef = primaryParentAssoc.getTarget();
+
+        final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v2/nodes";
+        final CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        final String newName = "NewName";
+        final String newTitle = "NewTitle";
+        String[] titleProperty = new String[]{newTitle};
+        HashMap<QName, String[]> properties = new HashMap<>();
+        properties.put(new QName(ContentModel.PROP_TITLE.toString()) , titleProperty);
+        JSONObject response = transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> {
+                    return doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.TESTFILE_NAME).toString(),newName, properties, 200);
+                }, false, true);
+
+        String newRef = (String) response.get("noderef");
+        JSONObject responseProperties = (JSONObject) ((JSONObject) response.get("metadata")).get("properties");
+        JSONArray responseNameProperty = (JSONArray) responseProperties.get(ContentModel.PROP_NAME.toString());
+        JSONArray responseTitleProperty = (JSONArray) responseProperties.get(ContentModel.PROP_TITLE.toString());
+        assertEquals(true, nodeService.exists(new NodeRef(newRef)));
+        assertEquals(newName, (String) responseNameProperty.get(0));
+        assertEquals(newTitle, (String) responseTitleProperty.get(0));
+
     }
 
     @Test
@@ -77,7 +116,7 @@ public class CopyNodeTest extends BaseTest {
 
         transactionService.getRetryingTransactionHelper()
                 .doInTransaction(() -> {
-                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME).toString(), 403);
+                    doTestCopy(httpclient, url, parentRef, initializedNodeRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME).toString(), null, null, 403);
                     return null;
                 }, false, true);
 
@@ -85,22 +124,54 @@ public class CopyNodeTest extends BaseTest {
         assertEquals(1, newChildAssocs.size());
     }
 
-    private void doTestCopy(CloseableHttpClient httpClient, String url, NodeRef parentRef, String targetRef, int expectedResponseCode) throws Throwable {
+    private JSONObject doTestCopy(CloseableHttpClient httpClient, String url, NodeRef parentRef, String copyFrom, String name, HashMap<QName, String[]> properties, int expectedResponseCode) throws Throwable {
         HttpPost httppost = new HttpPost(url);
-        String jsonString = json(String.format(
-                "{" +
-                        "\"parent\":\"%s\"," +
-                        "\"copyFrom\":\"%s\"" +
-                        "}"
-                , parentRef.toString(), targetRef));
+        String jsonBody = "{";
+        if ( parentRef != null ) {
+            jsonBody += "\"parent\":\"" + parentRef +  "\",";
+        }
+        if ( copyFrom != null ) {
+            jsonBody += "\"copyFrom\":\"" + copyFrom +  "\",";
+        }
+        if ( name != null ) {
+            jsonBody += "\"name\":\"" + name +  "\",";
+        }
+        if ( properties != null ) {
+            jsonBody += "\"properties\":{";
+            for (Map.Entry<QName, String[]> entry : properties.entrySet()){
+                jsonBody += "\""+ entry.getKey().toString() +"\":[";
+                    for (String value : entry.getValue()) {
+                        jsonBody += "\"" + value + "\",";
+                    }
+                    //Cut off last comma
+                    jsonBody = jsonBody.substring(0, jsonBody.length() - 1);
+                    jsonBody +=  "],";
+            }
+            //Cut off last comma
+            jsonBody = jsonBody.substring(0, jsonBody.length() - 1);
+            jsonBody += "}";
+        }
+        //Cut off last comma
+        System.out.println("Json body : " + jsonBody);
+        if (properties == null) {
+            jsonBody = jsonBody.substring(0, jsonBody.length() - 1);
+        }
+        jsonBody += "}";
+        String jsonString = json(jsonBody);
         httppost.setEntity(new StringEntity(jsonString));
-        List<ChildParentAssociation> childAssociations = nodeService.getChildAssociations(parentRef);
-        assertEquals(1, childAssociations.size());
 
+        String nodeInfo;
         try (CloseableHttpResponse response = httpClient.execute(httppost)) {
-            logger.debug(EntityUtils.toString(response.getEntity()));
+            nodeInfo = EntityUtils.toString(response.getEntity());
             assertEquals(expectedResponseCode, response.getStatusLine().getStatusCode());
         }
+
+        if (expectedResponseCode == 200) {
+            JSONParser parser = new JSONParser();
+            JSONObject json = (JSONObject) parser.parse(nodeInfo);
+            return json;
+        }
+        return null;
     }
 
     @After

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
@@ -39,9 +39,6 @@ public class CreateNodeOptions {
         this.parent = parent;
         this.name = name;
         this.type = type;
-        if (type == null && copyFrom != null) {
-            this.type = nodeService.getType(new NodeRef(copyFrom)).toString();
-        }
         this.properties = properties;
         if (this.properties == null) {
             this.properties = new HashMap<>(1);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
@@ -9,9 +9,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.alfresco.model.ContentModel;
-import org.alfresco.service.cmr.repository.NodeRef;
-import org.alfresco.service.cmr.repository.NodeService;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Created by Michiel Huygen on 12/05/2016.
@@ -26,9 +23,6 @@ public class CreateNodeOptions {
     public Map<QName, String[]> properties;
     public String copyFrom;
     private ObjectMapper mapper = new ObjectMapper();
-
-    @Autowired
-    NodeService nodeService;
 
     @JsonCreator
     public CreateNodeOptions(@JsonProperty("parent") String parent,

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.alfresco.model.ContentModel;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Created by Michiel Huygen on 12/05/2016.
@@ -24,6 +27,9 @@ public class CreateNodeOptions {
     public String copyFrom;
     private ObjectMapper mapper = new ObjectMapper();
 
+    @Autowired
+    NodeService nodeService;
+
     @JsonCreator
     public CreateNodeOptions(@JsonProperty("parent") String parent,
             @JsonProperty("name") String name,
@@ -33,6 +39,9 @@ public class CreateNodeOptions {
         this.parent = parent;
         this.name = name;
         this.type = type;
+        if (type == null && copyFrom != null) {
+            this.type = nodeService.getType(new NodeRef(copyFrom)).toString();
+        }
         this.properties = properties;
         if (this.properties == null) {
             this.properties = new HashMap<>(1);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -596,12 +596,14 @@ public class NodesWebscript1 extends ApixV1Webscript {
                         NodeRef nodeRef;
                         if (copyFrom == null) {
                             nodeRef = nodeService
-                                    .createNode(parent, createNodeOptions.properties,
-                                            new QName(createNodeOptions.type),
-                                            null);
+                                    .createNode(parent, createNodeOptions.name,
+                                            new QName(createNodeOptions.type));
                         } else {
                             nodeRef = nodeService.copyNode(copyFrom, parent, true);
                         }
+                        MetadataChanges metadataChanges = new MetadataChanges(new QName(createNodeOptions.type),
+                                null, null, createNodeOptions.properties);
+                        nodeService.setMetadata(nodeRef, metadataChanges);
                         return nodeRef;
                     }
                 }, false, true);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -624,12 +624,8 @@ public class NodesWebscript1 extends ApixV1Webscript {
                         }
                         metadataChanges = new MetadataChanges(type, null, null,
                                 createNodeOptions.properties);
-                        try {
-                            nodeService.setMetadata(nodeRef, metadataChanges);
-                        } catch (RuntimeException ex) {
-                            response.setStatus(HttpStatus.SC_BAD_REQUEST);
-                            writeJsonResponse(response, ex.getMessage());
-                        }
+                        nodeService.setMetadata(nodeRef, metadataChanges);
+
                         return nodeRef;
                     }
                 }, false, true);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -587,22 +587,41 @@ public class NodesWebscript1 extends ApixV1Webscript {
                     @Override
                     public Object execute() throws Throwable {
                         NodeRef parent = new NodeRef(createNodeOptions.parent);
-                        NodeRef copyFrom = null;
+                        MetadataChanges metadataChanges;
 
-                        if (createNodeOptions.copyFrom != null) {
-                            copyFrom = new NodeRef(createNodeOptions.copyFrom);
+                        if (!nodeService.exists(parent)) {
+                            response.setStatus(404);
+                            writeJsonResponse(response, "Parent does not exist");
+                            return null;
                         }
 
                         NodeRef nodeRef;
-                        if (copyFrom == null) {
+                        NodeRef copyFrom = null;
+                        if (createNodeOptions.copyFrom == null) {
                             nodeRef = nodeService
                                     .createNode(parent, createNodeOptions.name,
                                             new QName(createNodeOptions.type));
                         } else {
+                            copyFrom = new NodeRef(createNodeOptions.copyFrom);
+                            if (!nodeService.exists(copyFrom)) {
+                                response.setStatus(404);
+                                writeJsonResponse(response, "CopyFrom does not exist");
+                                return null;
+                            }
                             nodeRef = nodeService.copyNode(copyFrom, parent, true);
                         }
-                        MetadataChanges metadataChanges = new MetadataChanges(new QName(createNodeOptions.type),
-                                null, null, createNodeOptions.properties);
+
+                        if (createNodeOptions.type != null) {
+                            metadataChanges = new MetadataChanges(new QName(createNodeOptions.type),
+                                    null, null, createNodeOptions.properties);
+                        } else if ( createNodeOptions.type == null && createNodeOptions.copyFrom != null ) {
+                            metadataChanges = new MetadataChanges(nodeService.getMetadata(copyFrom).type,
+                                    null, null, createNodeOptions.properties);
+                        } else {
+                            response.setStatus(400);
+                            writeJsonResponse(response, "Please provide parameter: type when creating a new node");
+                            return null;
+                        }
                         nodeService.setMetadata(nodeRef, metadataChanges);
                         return nodeRef;
                     }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
@@ -262,12 +262,8 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
                         }
                         metadataChanges = new MetadataChanges(type, null, null,
                                 createNodeOptions.properties);
-                        try {
-                            nodeService.setMetadata(nodeRef, metadataChanges);
-                        } catch (RuntimeException ex) {
-                            response.setStatus(HttpStatus.SC_BAD_REQUEST);
-                            writeJsonResponse(response, ex.getMessage());
-                        }
+                        nodeService.setMetadata(nodeRef, metadataChanges);
+
                         return nodeRef;
                     }
                 }, false, true);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
@@ -224,7 +224,7 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
                     @Override
                     public Object execute() throws Throwable {
                         NodeRef parent = new NodeRef(createNodeOptions.parent);
-                        MetadataChanges metadataChanges = null;
+                        MetadataChanges metadataChanges;
 
                         if (!nodeService.exists(parent)) {
                             response.setStatus(404);

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/nodes/NodesWebscriptV2.java
@@ -9,6 +9,7 @@ import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.data.QName;
 import eu.xenit.apix.filefolder.IFileFolderService;
 import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.node.MetadataChanges;
 import eu.xenit.apix.permissions.IPermissionService;
 import eu.xenit.apix.permissions.PermissionValue;
 import eu.xenit.apix.rest.v1.nodes.CreateNodeOptions;
@@ -224,19 +225,25 @@ public class NodesWebscriptV2 extends ApixV2Webscript {
                     public Object execute() throws Throwable {
                         NodeRef parent = new NodeRef(createNodeOptions.parent);
                         NodeRef copyFrom = null;
-
+                        MetadataChanges metadataChanges = null;
                         if (createNodeOptions.copyFrom != null) {
                             copyFrom = new NodeRef(createNodeOptions.copyFrom);
+                            logger.debug("Type : " + createNodeOptions.type);
                         }
 
                         NodeRef nodeRef;
                         if (copyFrom == null) {
                             nodeRef = nodeService
-                                    .createNode(parent, createNodeOptions.properties, new QName(createNodeOptions.type),
-                                            null);
+                                    .createNode(parent, createNodeOptions.name,
+                                            new QName(createNodeOptions.type));
                         } else {
                             nodeRef = nodeService.copyNode(copyFrom, parent, true);
                         }
+
+                        metadataChanges = new MetadataChanges(new QName(createNodeOptions.type),
+                                null, null, createNodeOptions.properties);
+
+                        nodeService.setMetadata(nodeRef, metadataChanges);
                         return nodeRef;
                     }
                 }, false, true);


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-338

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
