### PR TITLE
Alfredapi 298 - Add CRUD api for comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,23 @@
 # Alfred API - Changelog
 
-## 2.5.3 UNRELEASED
+## 2.6.0 (UNRELEASED)
 
 ### Added
-
+* [ALFREDAPI-298](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Add CRUD api for comments
 
 ### Changed
 
-
 ### Fixed
-
 
 ### Deleted
 
 
-
 ## 2.5.2 (2020-08-12)
+
+### Fixed
+* [ALFREDAPI-338](https://xenitsupport.jira.com/browse/ALFREDAPI-338): Fixed issue when the provided name would not be set while copying a node
+
+## 2.5.1 (2020-08-05)
 
 ### Fixed
 * [ALFREDAPI-338](https://xenitsupport.jira.com/browse/ALFREDAPI-338): Fixed issue when the provided name would not be set while copying a node

--- a/apix-impl/50/src/main/java/eu/xenit/apix/alfresco50/CommentServiceImpl50.java
+++ b/apix-impl/50/src/main/java/eu/xenit/apix/alfresco50/CommentServiceImpl50.java
@@ -1,0 +1,94 @@
+package eu.xenit.apix.alfresco50;
+
+import com.github.dynamicextensionsalfresco.osgi.OsgiService;
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.alfresco.comments.CommentService;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.content.IContentService;
+import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.permissions.IPermissionService;
+import java.io.Serializable;
+import java.util.Set;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.site.SiteModel;
+import org.alfresco.service.cmr.lock.LockService;
+import org.alfresco.service.cmr.lock.LockStatus;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.security.AccessStatus;
+import org.alfresco.service.cmr.security.PermissionService;
+import org.alfresco.service.namespace.QName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service("eu.xenit.apix.comments.CommentService")
+@OsgiService
+public class CommentServiceImpl50 extends CommentService {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentServiceImpl50.class);
+
+    protected LockService alfLockService;
+    protected NodeService alfNodeService;
+    protected PermissionService alfPermissionService;
+
+    @Autowired
+    public CommentServiceImpl50(
+            LockService alfLockService,
+            NodeService alfNodeService,
+            PermissionService alfPermissionService,
+            org.alfresco.repo.forum.CommentService commentService,
+            IContentService contentService, INodeService nodeService,
+            IPermissionService permissionService,
+            ApixToAlfrescoConversion apixConverter) {
+        super(commentService, contentService, nodeService, permissionService, apixConverter);
+        this.alfLockService = alfLockService;
+        this.alfNodeService = alfNodeService;
+        this.alfPermissionService = alfPermissionService;
+    }
+
+    @Override
+    protected Comment setPermissions(NodeRef documentNode,
+            NodeRef commentNodeRef, Comment targetComment) {
+        boolean canEdit = false;
+        boolean canDelete = false;
+        if(!isWorkingCopyOrLocked(documentNode)) {
+            canEdit = canEditPermission(commentNodeRef);
+            canDelete = canDeletePermission(commentNodeRef);
+        }
+        targetComment.setCanEdit(canEdit);
+        targetComment.setCanDelete(canDelete);
+        return targetComment;
+    }
+
+    protected boolean isWorkingCopyOrLocked(NodeRef documentNode) {
+        boolean isworkingcopy = false;
+        boolean islocked = false;
+        if (alfNodeService.exists(documentNode)) {
+            Set<QName> documentAspects = alfNodeService.getAspects(documentNode);
+            isworkingcopy = documentAspects.contains(ContentModel.ASPECT_WORKING_COPY);
+            if (!isworkingcopy && documentAspects.contains(ContentModel.ASPECT_LOCKABLE)) {
+                log.debug("Node is not a working copy");
+                LockStatus lockStatus = alfLockService.getLockStatus(documentNode);
+                islocked = lockStatus == LockStatus.LOCKED;
+            }
+        }
+        return (isworkingcopy || islocked);
+    }
+
+    protected boolean canEditPermission(NodeRef commentNodeRef) {
+        String creator = (String) alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_CREATOR);
+        Serializable owner = alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_OWNER);
+        String currentUser = AuthenticationUtil.getFullyAuthenticatedUser();
+        boolean isSiteManager = alfPermissionService.hasPermission(commentNodeRef, SiteModel.SITE_MANAGER) == (AccessStatus.ALLOWED);
+        boolean isCoordinator = alfPermissionService.hasPermission(commentNodeRef, PermissionService.COORDINATOR) == (AccessStatus.ALLOWED);
+        return (isSiteManager || isCoordinator || currentUser.equals(creator) || currentUser.equals(owner));
+    }
+
+    protected boolean canDeletePermission(NodeRef commentNodeRef)
+    {
+        return alfPermissionService.hasPermission(commentNodeRef, PermissionService.DELETE) == AccessStatus.ALLOWED;
+    }
+}

--- a/apix-impl/50/src/main/java/eu/xenit/apix/alfresco50/CommentServiceImpl50.java
+++ b/apix-impl/50/src/main/java/eu/xenit/apix/alfresco50/CommentServiceImpl50.java
@@ -54,12 +54,12 @@ public class CommentServiceImpl50 extends CommentService {
             NodeRef commentNodeRef, Comment targetComment) {
         boolean canEdit = false;
         boolean canDelete = false;
-        if(!isWorkingCopyOrLocked(documentNode)) {
+        if (!isWorkingCopyOrLocked(documentNode)) {
             canEdit = canEditPermission(commentNodeRef);
             canDelete = canDeletePermission(commentNodeRef);
         }
-        targetComment.setCanEdit(canEdit);
-        targetComment.setCanDelete(canDelete);
+        targetComment.setEditable(canEdit);
+        targetComment.setDeletable(canDelete);
         return targetComment;
     }
 
@@ -82,13 +82,14 @@ public class CommentServiceImpl50 extends CommentService {
         String creator = (String) alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_CREATOR);
         Serializable owner = alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_OWNER);
         String currentUser = AuthenticationUtil.getFullyAuthenticatedUser();
-        boolean isSiteManager = alfPermissionService.hasPermission(commentNodeRef, SiteModel.SITE_MANAGER) == (AccessStatus.ALLOWED);
-        boolean isCoordinator = alfPermissionService.hasPermission(commentNodeRef, PermissionService.COORDINATOR) == (AccessStatus.ALLOWED);
+        boolean isSiteManager =
+                alfPermissionService.hasPermission(commentNodeRef, SiteModel.SITE_MANAGER) == (AccessStatus.ALLOWED);
+        boolean isCoordinator = alfPermissionService.hasPermission(commentNodeRef, PermissionService.COORDINATOR)
+                == (AccessStatus.ALLOWED);
         return (isSiteManager || isCoordinator || currentUser.equals(creator) || currentUser.equals(owner));
     }
 
-    protected boolean canDeletePermission(NodeRef commentNodeRef)
-    {
+    protected boolean canDeletePermission(NodeRef commentNodeRef) {
         return alfPermissionService.hasPermission(commentNodeRef, PermissionService.DELETE) == AccessStatus.ALLOWED;
     }
 }

--- a/apix-impl/51/src/main/java/eu/xenit/apix/alfresco51/CommentServiceImpl51.java
+++ b/apix-impl/51/src/main/java/eu/xenit/apix/alfresco51/CommentServiceImpl51.java
@@ -1,0 +1,94 @@
+package eu.xenit.apix.alfresco51;
+
+import com.github.dynamicextensionsalfresco.osgi.OsgiService;
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.alfresco.comments.CommentService;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.content.IContentService;
+import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.permissions.IPermissionService;
+import java.io.Serializable;
+import java.util.Set;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.site.SiteModel;
+import org.alfresco.service.cmr.lock.LockService;
+import org.alfresco.service.cmr.lock.LockStatus;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.security.AccessStatus;
+import org.alfresco.service.cmr.security.PermissionService;
+import org.alfresco.service.namespace.QName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service("eu.xenit.apix.comments.CommentService")
+@OsgiService
+public class CommentServiceImpl51 extends CommentService {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentServiceImpl51.class);
+
+    protected LockService alfLockService;
+    protected NodeService alfNodeService;
+    protected PermissionService alfPermissionService;
+
+    @Autowired
+    public CommentServiceImpl51(
+            LockService alfLockService,
+            NodeService alfNodeService,
+            PermissionService alfPermissionService,
+            org.alfresco.repo.forum.CommentService commentService,
+            IContentService contentService, INodeService nodeService,
+            IPermissionService permissionService,
+            ApixToAlfrescoConversion apixConverter) {
+        super(commentService, contentService, nodeService, permissionService, apixConverter);
+        this.alfLockService = alfLockService;
+        this.alfNodeService = alfNodeService;
+        this.alfPermissionService = alfPermissionService;
+    }
+
+    @Override
+    protected Comment setPermissions(NodeRef documentNode,
+            NodeRef commentNodeRef, Comment targetComment) {
+        boolean canEdit = false;
+        boolean canDelete = false;
+        if(!isWorkingCopyOrLocked(documentNode)) {
+            canEdit = canEditPermission(commentNodeRef);
+            canDelete = canDeletePermission(commentNodeRef);
+        }
+        targetComment.setCanEdit(canEdit);
+        targetComment.setCanDelete(canDelete);
+        return targetComment;
+    }
+
+    protected boolean isWorkingCopyOrLocked(NodeRef documentNode) {
+        boolean isworkingcopy = false;
+        boolean islocked = false;
+        if (alfNodeService.exists(documentNode)) {
+            Set<QName> documentAspects = alfNodeService.getAspects(documentNode);
+            isworkingcopy = documentAspects.contains(ContentModel.ASPECT_WORKING_COPY);
+            if (!isworkingcopy && documentAspects.contains(ContentModel.ASPECT_LOCKABLE)) {
+                log.debug("Node is not a working copy");
+                LockStatus lockStatus = alfLockService.getLockStatus(documentNode);
+                islocked = lockStatus == LockStatus.LOCKED;
+            }
+        }
+        return (isworkingcopy || islocked);
+    }
+
+    protected boolean canEditPermission(NodeRef commentNodeRef) {
+        String creator = (String) alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_CREATOR);
+        Serializable owner = alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_OWNER);
+        String currentUser = AuthenticationUtil.getFullyAuthenticatedUser();
+        boolean isSiteManager = alfPermissionService.hasPermission(commentNodeRef, SiteModel.SITE_MANAGER) == (AccessStatus.ALLOWED);
+        boolean isCoordinator = alfPermissionService.hasPermission(commentNodeRef, PermissionService.COORDINATOR) == (AccessStatus.ALLOWED);
+        return (isSiteManager || isCoordinator || currentUser.equals(creator) || currentUser.equals(owner));
+    }
+
+    protected boolean canDeletePermission(NodeRef commentNodeRef)
+    {
+        return alfPermissionService.hasPermission(commentNodeRef, PermissionService.DELETE) == AccessStatus.ALLOWED;
+    }
+}

--- a/apix-impl/51/src/main/java/eu/xenit/apix/alfresco51/CommentServiceImpl51.java
+++ b/apix-impl/51/src/main/java/eu/xenit/apix/alfresco51/CommentServiceImpl51.java
@@ -54,12 +54,12 @@ public class CommentServiceImpl51 extends CommentService {
             NodeRef commentNodeRef, Comment targetComment) {
         boolean canEdit = false;
         boolean canDelete = false;
-        if(!isWorkingCopyOrLocked(documentNode)) {
+        if (!isWorkingCopyOrLocked(documentNode)) {
             canEdit = canEditPermission(commentNodeRef);
             canDelete = canDeletePermission(commentNodeRef);
         }
-        targetComment.setCanEdit(canEdit);
-        targetComment.setCanDelete(canDelete);
+        targetComment.setEditable(canEdit);
+        targetComment.setDeletable(canDelete);
         return targetComment;
     }
 
@@ -82,13 +82,14 @@ public class CommentServiceImpl51 extends CommentService {
         String creator = (String) alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_CREATOR);
         Serializable owner = alfNodeService.getProperty(commentNodeRef, ContentModel.PROP_OWNER);
         String currentUser = AuthenticationUtil.getFullyAuthenticatedUser();
-        boolean isSiteManager = alfPermissionService.hasPermission(commentNodeRef, SiteModel.SITE_MANAGER) == (AccessStatus.ALLOWED);
-        boolean isCoordinator = alfPermissionService.hasPermission(commentNodeRef, PermissionService.COORDINATOR) == (AccessStatus.ALLOWED);
+        boolean isSiteManager =
+                alfPermissionService.hasPermission(commentNodeRef, SiteModel.SITE_MANAGER) == (AccessStatus.ALLOWED);
+        boolean isCoordinator = alfPermissionService.hasPermission(commentNodeRef, PermissionService.COORDINATOR)
+                == (AccessStatus.ALLOWED);
         return (isSiteManager || isCoordinator || currentUser.equals(creator) || currentUser.equals(owner));
     }
 
-    protected boolean canDeletePermission(NodeRef commentNodeRef)
-    {
+    protected boolean canDeletePermission(NodeRef commentNodeRef) {
         return alfPermissionService.hasPermission(commentNodeRef, PermissionService.DELETE) == AccessStatus.ALLOWED;
     }
 }

--- a/apix-impl/52/src/main/java/eu/xenit/apix/alfresco52/CommentServiceImpl52.java
+++ b/apix-impl/52/src/main/java/eu/xenit/apix/alfresco52/CommentServiceImpl52.java
@@ -8,6 +8,7 @@ import eu.xenit.apix.content.IContentService;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.permissions.IPermissionService;
 import java.util.Map;
+import org.alfresco.service.cmr.repository.NodeRef;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -24,11 +25,10 @@ public class CommentServiceImpl52 extends CommentService {
     }
 
     @Override
-    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
-            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
+    protected Comment setPermissions(NodeRef documentNode, NodeRef commentNodeRef, Comment targetComment) {
         Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
-        targetComment.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
-        targetComment.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        targetComment.setEditable(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        targetComment.setDeletable(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
         return targetComment;
     }
 }

--- a/apix-impl/52/src/main/java/eu/xenit/apix/alfresco52/CommentServiceImpl52.java
+++ b/apix-impl/52/src/main/java/eu/xenit/apix/alfresco52/CommentServiceImpl52.java
@@ -1,0 +1,34 @@
+package eu.xenit.apix.alfresco52;
+
+import com.github.dynamicextensionsalfresco.osgi.OsgiService;
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.alfresco.comments.CommentService;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.content.IContentService;
+import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.permissions.IPermissionService;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service("eu.xenit.apix.comments.CommentService")
+@OsgiService
+public class CommentServiceImpl52 extends CommentService {
+
+    @Autowired
+    public CommentServiceImpl52(org.alfresco.repo.forum.CommentService commentService,
+            IContentService contentService, INodeService nodeService,
+            IPermissionService permissionService,
+            ApixToAlfrescoConversion apixConverter) {
+        super(commentService, contentService, nodeService, permissionService, apixConverter);
+    }
+
+    @Override
+    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
+            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
+        Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
+        targetComment.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        targetComment.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        return targetComment;
+    }
+}

--- a/apix-impl/60/src/main/java/eu/xenit/apix/alfresco60/CommentServiceImpl60.java
+++ b/apix-impl/60/src/main/java/eu/xenit/apix/alfresco60/CommentServiceImpl60.java
@@ -1,0 +1,34 @@
+package eu.xenit.apix.alfresco60;
+
+import com.github.dynamicextensionsalfresco.osgi.OsgiService;
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.alfresco.comments.CommentService;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.content.IContentService;
+import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.permissions.IPermissionService;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service("eu.xenit.apix.comments.CommentService")
+@OsgiService
+public class CommentServiceImpl60 extends CommentService {
+
+    @Autowired
+    public CommentServiceImpl60(org.alfresco.repo.forum.CommentService commentService,
+            IContentService contentService, INodeService nodeService,
+            IPermissionService permissionService,
+            ApixToAlfrescoConversion apixConverter) {
+        super(commentService, contentService, nodeService, permissionService, apixConverter);
+    }
+
+    @Override
+    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
+            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
+        Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
+        targetComment.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        targetComment.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        return targetComment;
+    }
+}

--- a/apix-impl/60/src/main/java/eu/xenit/apix/alfresco60/CommentServiceImpl60.java
+++ b/apix-impl/60/src/main/java/eu/xenit/apix/alfresco60/CommentServiceImpl60.java
@@ -8,6 +8,7 @@ import eu.xenit.apix.content.IContentService;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.permissions.IPermissionService;
 import java.util.Map;
+import org.alfresco.service.cmr.repository.NodeRef;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -24,11 +25,10 @@ public class CommentServiceImpl60 extends CommentService {
     }
 
     @Override
-    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
-            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
+    protected Comment setPermissions(NodeRef documentNode, NodeRef commentNodeRef, Comment targetComment) {
         Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
-        targetComment.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
-        targetComment.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        targetComment.setEditable(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        targetComment.setDeletable(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
         return targetComment;
     }
 }

--- a/apix-impl/61/src/main/java/eu/xenit/apix/alfresco61/CommentServiceImpl61.java
+++ b/apix-impl/61/src/main/java/eu/xenit/apix/alfresco61/CommentServiceImpl61.java
@@ -8,6 +8,7 @@ import eu.xenit.apix.content.IContentService;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.permissions.IPermissionService;
 import java.util.Map;
+import org.alfresco.service.cmr.repository.NodeRef;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -24,11 +25,10 @@ public class CommentServiceImpl61 extends CommentService {
     }
 
     @Override
-    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
-            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
+    protected Comment setPermissions(NodeRef documentNode, NodeRef commentNodeRef, Comment targetComment) {
         Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
-        targetComment.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
-        targetComment.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        targetComment.setEditable(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        targetComment.setDeletable(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
         return targetComment;
     }
 }

--- a/apix-impl/61/src/main/java/eu/xenit/apix/alfresco61/CommentServiceImpl61.java
+++ b/apix-impl/61/src/main/java/eu/xenit/apix/alfresco61/CommentServiceImpl61.java
@@ -1,0 +1,34 @@
+package eu.xenit.apix.alfresco61;
+
+import com.github.dynamicextensionsalfresco.osgi.OsgiService;
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.alfresco.comments.CommentService;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.content.IContentService;
+import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.permissions.IPermissionService;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service("eu.xenit.apix.comments.CommentService")
+@OsgiService
+public class CommentServiceImpl61 extends CommentService {
+
+    @Autowired
+    public CommentServiceImpl61(org.alfresco.repo.forum.CommentService commentService,
+            IContentService contentService, INodeService nodeService,
+            IPermissionService permissionService,
+            ApixToAlfrescoConversion apixConverter) {
+        super(commentService, contentService, nodeService, permissionService, apixConverter);
+    }
+
+    @Override
+    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
+            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
+        Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
+        targetComment.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        targetComment.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        return targetComment;
+    }
+}

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CommentsTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/rest/v1/tests/CommentsTest.java
@@ -1,0 +1,92 @@
+package eu.xenit.apix.rest.v1.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.data.NodeRef;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import org.alfresco.repo.forum.CommentService;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CommentsTest extends BaseTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentsTest.class);
+
+    private static final String commentTitle = "commentTitle";
+    private static final String commentContent = "Comment Content";
+    private static final String COMMENTNODE1 = "testComment";
+    private static final String COMMENTNODE_NORIGHTS = "testComment_noRights";
+    private static final String SKIPCOUNT = "skipcount";
+    private static final String PAGESIZE = "pagesize";
+
+    @Autowired
+    private CommentService alfrescoCommentService;
+
+    @Autowired
+    private ApixToAlfrescoConversion apixConverter;
+
+    @Override
+    public HashMap<String, NodeRef> init() {
+        HashMap<String, NodeRef> response = super.init();
+        response = initComments(response);
+        return response;
+    }
+
+    private HashMap<String, NodeRef> initComments(HashMap<String, NodeRef> initializedNodeRefs) {
+        org.alfresco.service.cmr.repository.NodeRef alfrescoCommentNode = alfrescoCommentService
+                .createComment(apixConverter.alfresco(initializedNodeRefs.get(TESTFILE_NAME)), commentTitle,
+                        commentContent, false);
+        initializedNodeRefs.put(COMMENTNODE1, new NodeRef(alfrescoCommentNode.toString()));
+        org.alfresco.service.cmr.repository.NodeRef alfrescoCommentNode2 = alfrescoCommentService
+                .createComment(apixConverter.alfresco(initializedNodeRefs.get(NOUSERRIGHTS_FILE_NAME)), commentTitle,
+                        commentContent, false);
+        initializedNodeRefs.put(COMMENTNODE_NORIGHTS, new NodeRef(alfrescoCommentNode2.toString()));
+        return initializedNodeRefs;
+    }
+
+    @Test
+    public void test_getComments() throws IOException, URISyntaxException {
+        HashMap<String, NodeRef> initializedRefs = init();
+        String url = makeNodesUrl(initializedRefs.get(BaseTest.TESTFILE_NAME), "/comments", "admin", "admin");
+        log.info("URL: {}", url);
+        URIBuilder builder = new URIBuilder(url);
+        builder.addParameter(PAGESIZE, "10");
+        builder.addParameter(SKIPCOUNT,"0");
+        HttpResponse httpResponse = Request.Get(builder.build()).execute().returnResponse();
+        assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void test_getComments_accessDenied() throws IOException, URISyntaxException {
+        HashMap<String, NodeRef> initializedRefs = init();
+        String url = makeNodesUrl(initializedRefs.get(BaseTest.NOUSERRIGHTS_FILE_NAME), "/comments", BaseTest.USERWITHOUTRIGHTS,
+                BaseTest.USERWITHOUTRIGHTS);
+        log.info("URL: {}", url);
+        URIBuilder builder = new URIBuilder(url);
+        builder.addParameter(PAGESIZE, "10");
+        builder.addParameter(SKIPCOUNT,"0");
+        HttpResponse httpResponse = Request.Get(builder.build()).execute().returnResponse();
+        assertEquals(403, httpResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void test_getComments_notFound() throws IOException, URISyntaxException {
+        HashMap<String, NodeRef> initializedRefs = init();
+        String url = makeNodesUrl(new NodeRef("workspace://SpacesStore/00000000-0000-0000-0000-000000000000"), "/comments", "admin", "admin");
+        log.info("URL: {}", url);
+        URIBuilder builder = new URIBuilder(url);
+        builder.addParameter(PAGESIZE, "10");
+        builder.addParameter(SKIPCOUNT,"0");
+        HttpResponse httpResponse = Request.Get(builder.build()).execute().returnResponse();
+        assertEquals(404, httpResponse.getStatusLine().getStatusCode());
+    }
+
+}

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/comments/CommentServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/comments/CommentServiceTest.java
@@ -63,7 +63,7 @@ public class CommentServiceTest extends BaseTest {
                 .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
         Conversation actual = commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 0, 10);
         assertTrue(actual.isCreatable());
-        assertFalse(actual.isHasMore());
+        assertFalse(actual.hasMore());
         assertEquals(1, actual.getComments().size());
         Comment apixComment = actual.getComments().get(0);
         assertEquals(apixConversion.apix(commentNode), apixComment.getId());
@@ -81,7 +81,7 @@ public class CommentServiceTest extends BaseTest {
         alfrescoCommentService.createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
         alfrescoCommentService.createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
         Conversation actual = commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 0, 1);
-        assertTrue(actual.isHasMore());
+        assertTrue(actual.hasMore());
         assertEquals(1, actual.getComments().size());
     }
 

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/comments/CommentServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/comments/CommentServiceTest.java
@@ -19,7 +19,6 @@ import org.alfresco.service.cmr.model.FileInfo;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.namespace.QName;
-import org.alfresco.util.ISO8601DateFormat;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +62,7 @@ public class CommentServiceTest extends BaseTest {
         NodeRef commentNode = alfrescoCommentService
                 .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
         Conversation actual = commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 0, 10);
-        assertTrue(actual.isCanCreate());
+        assertTrue(actual.isCreatable());
         assertFalse(actual.isHasMore());
         assertEquals(1, actual.getComments().size());
         Comment apixComment = actual.getComments().get(0);
@@ -73,8 +72,8 @@ public class CommentServiceTest extends BaseTest {
         Map<QName, Serializable> commentProperties = alfrescoNodeService.getProperties(commentNode);
         assertEquals(commentProperties.get(ContentModel.PROP_CREATOR), apixComment.getCreatedBy());
         assertEquals(commentProperties.get(ContentModel.PROP_MODIFIER), apixComment.getModifiedBy());
-        assertTrue(apixComment.isCanEdit());
-        assertTrue(apixComment.isCanDelete());
+        assertTrue(apixComment.isEditable());
+        assertTrue(apixComment.isDeletable());
     }
 
     @Test

--- a/apix-impl/src/integration-test/java/eu/xenit/apix/tests/comments/CommentServiceTest.java
+++ b/apix-impl/src/integration-test/java/eu/xenit/apix/tests/comments/CommentServiceTest.java
@@ -1,0 +1,132 @@
+package eu.xenit.apix.tests.comments;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.comments.Conversation;
+import eu.xenit.apix.comments.ICommentService;
+import eu.xenit.apix.tests.BaseTest;
+import java.io.Serializable;
+import java.util.Map;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.forum.CommentService;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.model.FileInfo;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.util.ISO8601DateFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CommentServiceTest extends BaseTest {
+
+    private static final String commentTitle = "testComment";
+    private static final String commentContent = "Test Comment";
+    private static FileInfo testDocumentNode;
+
+    @Autowired
+    private ICommentService commentService;
+    @Autowired
+    private ApixToAlfrescoConversion apixConversion;
+    @Autowired
+    private ServiceRegistry serviceRegistry;
+    @Autowired
+    private CommentService alfrescoCommentService;
+
+    @Before
+    public void setupComments() {
+        AuthenticationUtil.setAdminUserAsFullyAuthenticatedUser();
+        cleanUp();
+        NodeRef companyHomeRef = repository.getCompanyHome();
+        FileInfo mainTestFolder = createMainTestFolder(companyHomeRef);
+        testDocumentNode = this.createTestNode(mainTestFolder.getNodeRef(), "testNode");
+    }
+
+    @Test
+    public void test_getDocumentForComment() {
+        NodeRef commentNode = alfrescoCommentService
+                .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        eu.xenit.apix.data.NodeRef documentApixNode = commentService
+                .getTargetDocumentForComment(apixConversion.apix(commentNode));
+        assertEquals(apixConversion.apix(testDocumentNode.getNodeRef()), documentApixNode);
+    }
+
+    @Test
+    public void test_getComments_withHasMoreIsFalse() {
+        NodeService alfrescoNodeService = serviceRegistry.getNodeService();
+        NodeRef commentNode = alfrescoCommentService
+                .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        Conversation actual = commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 0, 10);
+        assertTrue(actual.isCanCreate());
+        assertFalse(actual.isHasMore());
+        assertEquals(1, actual.getComments().size());
+        Comment apixComment = actual.getComments().get(0);
+        assertEquals(apixConversion.apix(commentNode), apixComment.getId());
+        assertEquals(commentTitle, apixComment.getTitle());
+        assertEquals(commentContent, apixComment.getContent());
+        Map<QName, Serializable> commentProperties = alfrescoNodeService.getProperties(commentNode);
+        assertEquals(commentProperties.get(ContentModel.PROP_CREATOR), apixComment.getCreatedBy());
+        assertEquals(commentProperties.get(ContentModel.PROP_MODIFIER), apixComment.getModifiedBy());
+        assertTrue(apixComment.isCanEdit());
+        assertTrue(apixComment.isCanDelete());
+    }
+
+    @Test
+    public void test_getComments_withHasMoreIsTrue_withPageSize() {
+        alfrescoCommentService.createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        alfrescoCommentService.createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        Conversation actual = commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 0, 1);
+        assertTrue(actual.isHasMore());
+        assertEquals(1, actual.getComments().size());
+    }
+
+    @Test
+    public void test_getComments_withSkipCount_withPageSize() {
+        //order is of nodes chronologically descending (highest index = oldest node)
+        NodeRef oldestNode = alfrescoCommentService
+                .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        alfrescoCommentService.createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        Conversation actual = commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 1, 1);
+        assertEquals(1, actual.getComments().size());
+        assertEquals(apixConversion.apix(oldestNode), actual.getComments().get(0).getId());
+    }
+
+    @Test
+    public void test_addNewComment() {
+        eu.xenit.apix.data.NodeRef apixTestDocNode = apixConversion.apix(testDocumentNode.getNodeRef());
+        Comment newComment = commentService.addNewComment(apixTestDocNode, commentContent);
+        Conversation actual = commentService.getComments(apixTestDocNode, 0, 10);
+        assertEquals(1, actual.getComments().size());
+        assertEquals(newComment, actual.getComments().get(0));
+    }
+
+    @Test
+    public void test_updateComment() {
+        NodeRef alfrescoCommentNode = alfrescoCommentService
+                .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        eu.xenit.apix.data.NodeRef apixCommentNode = apixConversion.apix(alfrescoCommentNode);
+        String newCommentContent = "New Content";
+        commentService.updateComment(apixCommentNode, newCommentContent);
+        eu.xenit.apix.data.NodeRef apixTestDocNode = apixConversion.apix(testDocumentNode.getNodeRef());
+        Conversation actual = commentService.getComments(apixTestDocNode, 0, 1);
+        assertEquals(1, actual.getComments().size());
+        assertEquals(newCommentContent, actual.getComments().get(0).getContent());
+        assertEquals(apixCommentNode, actual.getComments().get(0).getId());
+    }
+
+    @Test
+    public void test_deleteComment() {
+        NodeRef alfrescoCommentNodeRef = alfrescoCommentService
+                .createComment(testDocumentNode.getNodeRef(), commentTitle, commentContent, false);
+        commentService.deleteComment(apixConversion.apix(alfrescoCommentNodeRef));
+        assertEquals(0,
+                commentService.getComments(apixConversion.apix(testDocumentNode.getNodeRef()), 0, 10).getComments()
+                        .size());
+    }
+}

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
@@ -18,9 +18,6 @@ import org.alfresco.model.ContentModel;
 import org.alfresco.query.PagingRequest;
 import org.alfresco.query.PagingResults;
 import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class CommentService implements ICommentService {
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
@@ -22,9 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class CommentService implements ICommentService {
-
-    private static final Logger log = LoggerFactory.getLogger(CommentService.class);
+public abstract class CommentService implements ICommentService {
 
     protected org.alfresco.repo.forum.CommentService commentService;
 
@@ -127,8 +125,6 @@ public class CommentService implements ICommentService {
         return response;
     }
 
-    protected Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
-            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment) {
-        return targetComment;
-    }
+    protected abstract Comment setPermissions(org.alfresco.service.cmr.repository.NodeRef documentNode,
+            org.alfresco.service.cmr.repository.NodeRef commentNodeRef, Comment targetComment);
 }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
@@ -90,6 +90,11 @@ public class CommentService implements ICommentService {
         commentService.deleteComment(apixConverter.alfresco(targetCommentNode));
     }
 
+    @Override
+    public boolean canCreateComment(NodeRef targetNodeRef) {
+        return permissionService.hasPermission(targetNodeRef, IPermissionService.CREATE_CHILDREN);
+    }
+
     private Comment toComment(org.alfresco.service.cmr.repository.NodeRef documentNode,
             org.alfresco.service.cmr.repository.NodeRef commentNodeRef) {
         NodeRef apixCommentNodeRef = apixConverter.apix(commentNodeRef);
@@ -126,12 +131,7 @@ public class CommentService implements ICommentService {
         }
         Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
         response.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
-        response.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        response.setCanDelete(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
         return response;
-    }
-
-    @Override
-    public boolean canCreateComment(NodeRef targetNodeRef) {
-        return permissionService.hasPermission(targetNodeRef, IPermissionService.CREATE_CHILDREN);
     }
 }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/comments/CommentService.java
@@ -1,0 +1,137 @@
+package eu.xenit.apix.alfresco.comments;
+
+import com.github.dynamicextensionsalfresco.osgi.OsgiService;
+import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.comments.Conversation;
+import eu.xenit.apix.comments.ICommentService;
+import eu.xenit.apix.content.IContentService;
+import eu.xenit.apix.data.NodeRef;
+import eu.xenit.apix.data.QName;
+import eu.xenit.apix.node.INodeService;
+import eu.xenit.apix.node.NodeMetadata;
+import eu.xenit.apix.permissions.IPermissionService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.alfresco.model.ContentModel;
+import org.alfresco.query.PagingRequest;
+import org.alfresco.query.PagingResults;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+@OsgiService
+@Component("eu.xenit.apix.alfresco.comments.CommentService")
+public class CommentService implements ICommentService {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentService.class);
+
+    private org.alfresco.repo.forum.CommentService commentService;
+
+    private IContentService contentService;
+    private INodeService nodeService;
+    private IPermissionService permissionService;
+    private ApixToAlfrescoConversion apixConverter;
+
+    @Autowired
+    public CommentService(org.alfresco.repo.forum.CommentService commentService, IContentService contentService,
+            INodeService nodeService, IPermissionService permissionService, ApixToAlfrescoConversion apixConverter) {
+        this.commentService = commentService;
+
+        this.contentService = contentService;
+        this.nodeService = nodeService;
+        this.permissionService = permissionService;
+        this.apixConverter = apixConverter;
+    }
+
+    @Override
+    public NodeRef getTargetDocumentForComment(NodeRef commentNodeRef) {
+        return apixConverter.apix(commentService.getDiscussableAncestor(apixConverter.alfresco(commentNodeRef)));
+    }
+
+    @Override
+    public Conversation getComments(NodeRef targetNode, int skipCount, int pageSize) {
+        org.alfresco.service.cmr.repository.NodeRef alfTargetNode = apixConverter.alfresco(targetNode);
+        PagingResults<org.alfresco.service.cmr.repository.NodeRef> commentAlfNodes =
+                commentService.listComments(alfTargetNode, new PagingRequest(skipCount, pageSize));
+        return new Conversation()
+                .comments(commentAlfNodes.getPage().stream()
+                        .map(alfCommentNode -> toComment(alfTargetNode, alfCommentNode)).collect(Collectors.toList()))
+                .hasMore(commentAlfNodes.hasMoreItems())
+                .canCreate(canCreateComment(targetNode));
+    }
+
+    @Override
+    public Comment addNewComment(NodeRef targetNode, String content) {
+        org.alfresco.service.cmr.repository.NodeRef alfTargetNode = apixConverter.alfresco(targetNode);
+        return toComment(alfTargetNode, commentService.createComment(alfTargetNode, "", content, false));
+    }
+
+    @Override
+    public Comment updateComment(NodeRef targetCommentNode, String content) {
+        return updateComment(getTargetDocumentForComment(targetCommentNode), targetCommentNode, content);
+    }
+
+    @Override
+    public Comment updateComment(NodeRef targetDocumentNode, NodeRef targetCommentNode, String content) {
+        org.alfresco.service.cmr.repository.NodeRef alfTargetCommentNode = apixConverter.alfresco(targetCommentNode);
+        commentService.updateComment(alfTargetCommentNode, "", content);
+        org.alfresco.service.cmr.repository.NodeRef alfTargetDocumentNode = apixConverter.alfresco(targetDocumentNode);
+        return toComment(alfTargetDocumentNode, alfTargetCommentNode);
+    }
+
+    @Override
+    public void deleteComment(NodeRef targetCommentNode) {
+        commentService.deleteComment(apixConverter.alfresco(targetCommentNode));
+    }
+
+    private Comment toComment(org.alfresco.service.cmr.repository.NodeRef documentNode,
+            org.alfresco.service.cmr.repository.NodeRef commentNodeRef) {
+        NodeRef apixCommentNodeRef = apixConverter.apix(commentNodeRef);
+        NodeMetadata commentMetadata = nodeService.getMetadata(apixCommentNodeRef);
+        String content;
+        try {
+            content = IOUtils.toString(contentService.getContent(apixCommentNodeRef).getInputStream());
+        } catch (IOException ioException) {
+            log.error("Error reading content for comment {}", commentNodeRef, ioException);
+            content = "Comment not available: error reading content";
+        }
+        Comment response = new Comment();
+        response.setId(apixCommentNodeRef);
+        response.setContent(content);
+        List<String> property = commentMetadata.properties.get(new QName(ContentModel.PROP_TITLE.toString()));
+        if (property != null && !property.isEmpty()) {
+            response.setTitle(property.get(0));
+        }
+        property = commentMetadata.properties.get(new QName(ContentModel.PROP_CREATED.toString()));
+        if (property != null && !property.isEmpty()) {
+            response.setCreatedAt(property.get(0));
+        }
+        property = commentMetadata.properties.get(new QName(ContentModel.PROP_CREATOR.toString()));
+        if (property != null && !property.isEmpty()) {
+            response.setCreatedBy(property.get(0));
+        }
+        property = commentMetadata.properties.get(new QName(ContentModel.PROP_MODIFIED.toString()));
+        if (property != null && !property.isEmpty()) {
+            response.setModifiedAt(property.get(0));
+        }
+        property = commentMetadata.properties.get(new QName(ContentModel.PROP_MODIFIER.toString()));
+        if (property != null && !property.isEmpty()) {
+            response.setModifiedBy(property.get(0));
+        }
+        Map<String, Boolean> commentPermissionMap = commentService.getCommentPermissions(documentNode, commentNodeRef);
+        response.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_EDIT));
+        response.setCanEdit(commentPermissionMap.get(org.alfresco.repo.forum.CommentService.CAN_DELETE));
+        return response;
+    }
+
+    @Override
+    public boolean canCreateComment(NodeRef targetNodeRef) {
+        return permissionService.hasPermission(targetNodeRef, IPermissionService.CREATE_CHILDREN);
+    }
+}

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.comments;
 
 import eu.xenit.apix.data.NodeRef;
+import java.util.Objects;
 
 public class Comment {
 
@@ -129,5 +130,25 @@ public class Comment {
     public Comment canDelete(boolean canDelete) {
         setCanDelete(canDelete);
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Comment)) {
+            return false;
+        }
+        Comment comment = (Comment) o;
+        return getId().equals(comment.getId()) &&
+                getContent().equals(comment.getContent()) &&
+                Objects.equals(getCreatedBy(), comment.getCreatedBy()) &&
+                Objects.equals(getModifiedBy(), comment.getModifiedBy());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getContent(), getCreatedBy(), getModifiedBy());
     }
 }

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
@@ -23,22 +23,12 @@ public class Comment {
         this.id = id;
     }
 
-    public Comment id(NodeRef id) {
-        setId(id);
-        return this;
-    }
-
     public String getTitle() {
         return title;
     }
 
     public void setTitle(String title) {
         this.title = title;
-    }
-
-    public Comment title(String title) {
-        setTitle(title);
-        return this;
     }
 
     public String getContent() {
@@ -49,22 +39,12 @@ public class Comment {
         this.content = content;
     }
 
-    public Comment content(String content) {
-        setContent(content);
-        return this;
-    }
-
     public String getCreatedAt() {
         return createdAt;
     }
 
     public void setCreatedAt(String createdAt) {
         this.createdAt = createdAt;
-    }
-
-    public Comment createdAt(String createdAt) {
-        setCreatedAt(createdAt);
-        return this;
     }
 
     public String getCreatedBy() {
@@ -75,22 +55,12 @@ public class Comment {
         this.createdBy = createdBy;
     }
 
-    public Comment createdBy(String createdBy) {
-        setCreatedBy(createdBy);
-        return this;
-    }
-
     public String getModifiedAt() {
         return modifiedAt;
     }
 
     public void setModifiedAt(String modifiedAt) {
         this.modifiedAt = modifiedAt;
-    }
-
-    public Comment modifiedAt(String modifiedAt) {
-        setModifiedAt(modifiedAt);
-        return this;
     }
 
     public String getModifiedBy() {
@@ -101,11 +71,6 @@ public class Comment {
         this.modifiedBy = modifiedBy;
     }
 
-    public Comment modifiedBy(String modifiedBy) {
-        setModifiedBy(modifiedBy);
-        return this;
-    }
-
     public boolean isCanEdit() {
         return canEdit;
     }
@@ -114,22 +79,12 @@ public class Comment {
         this.canEdit = canEdit;
     }
 
-    public Comment canEdit(boolean canEdit) {
-        setCanEdit(canEdit);
-        return this;
-    }
-
     public boolean isCanDelete() {
         return canDelete;
     }
 
     public void setCanDelete(boolean canDelete) {
         this.canDelete = canDelete;
-    }
-
-    public Comment canDelete(boolean canDelete) {
-        setCanDelete(canDelete);
-        return this;
     }
 
     @Override

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
@@ -12,8 +12,8 @@ public class Comment {
     private String createdBy;
     private String modifiedAt;
     private String modifiedBy;
-    private boolean canEdit;
-    private boolean canDelete;
+    private boolean editable;
+    private boolean deletable;
 
     public NodeRef getId() {
         return id;
@@ -71,20 +71,20 @@ public class Comment {
         this.modifiedBy = modifiedBy;
     }
 
-    public boolean isCanEdit() {
-        return canEdit;
+    public boolean isEditable() {
+        return editable;
     }
 
-    public void setCanEdit(boolean canEdit) {
-        this.canEdit = canEdit;
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 
-    public boolean isCanDelete() {
-        return canDelete;
+    public boolean isDeletable() {
+        return deletable;
     }
 
-    public void setCanDelete(boolean canDelete) {
-        this.canDelete = canDelete;
+    public void setDeletable(boolean deletable) {
+        this.deletable = deletable;
     }
 
     @Override

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Comment.java
@@ -1,0 +1,133 @@
+package eu.xenit.apix.comments;
+
+import eu.xenit.apix.data.NodeRef;
+
+public class Comment {
+
+    private NodeRef id;
+    private String title;
+    private String content;
+    private String createdAt;
+    private String createdBy;
+    private String modifiedAt;
+    private String modifiedBy;
+    private boolean canEdit;
+    private boolean canDelete;
+
+    public NodeRef getId() {
+        return id;
+    }
+
+    public void setId(NodeRef id) {
+        this.id = id;
+    }
+
+    public Comment id(NodeRef id) {
+        setId(id);
+        return this;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Comment title(String title) {
+        setTitle(title);
+        return this;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Comment content(String content) {
+        setContent(content);
+        return this;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Comment createdAt(String createdAt) {
+        setCreatedAt(createdAt);
+        return this;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Comment createdBy(String createdBy) {
+        setCreatedBy(createdBy);
+        return this;
+    }
+
+    public String getModifiedAt() {
+        return modifiedAt;
+    }
+
+    public void setModifiedAt(String modifiedAt) {
+        this.modifiedAt = modifiedAt;
+    }
+
+    public Comment modifiedAt(String modifiedAt) {
+        setModifiedAt(modifiedAt);
+        return this;
+    }
+
+    public String getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+
+    public Comment modifiedBy(String modifiedBy) {
+        setModifiedBy(modifiedBy);
+        return this;
+    }
+
+    public boolean isCanEdit() {
+        return canEdit;
+    }
+
+    public void setCanEdit(boolean canEdit) {
+        this.canEdit = canEdit;
+    }
+
+    public Comment canEdit(boolean canEdit) {
+        setCanEdit(canEdit);
+        return this;
+    }
+
+    public boolean isCanDelete() {
+        return canDelete;
+    }
+
+    public void setCanDelete(boolean canDelete) {
+        this.canDelete = canDelete;
+    }
+
+    public Comment canDelete(boolean canDelete) {
+        setCanDelete(canDelete);
+        return this;
+    }
+}

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
@@ -1,0 +1,50 @@
+package eu.xenit.apix.comments;
+
+import java.util.List;
+
+public class Conversation {
+
+    private List<Comment> comments;
+    private boolean hasMore;
+    private boolean canCreate;
+
+    public List<Comment> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
+
+    public Conversation comments(List<Comment> comments) {
+        setComments(comments);
+        return this;
+    }
+
+    public boolean isHasMore() {
+        return hasMore;
+    }
+
+    public void setHasMore(boolean hasMore) {
+        this.hasMore = hasMore;
+    }
+
+    public Conversation hasMore(boolean hasMore) {
+        setHasMore(hasMore);
+        return this;
+    }
+
+    public boolean isCanCreate() {
+        return canCreate;
+    }
+
+    public void setCanCreate(boolean canCreate) {
+        this.canCreate = canCreate;
+    }
+
+    public Conversation canCreate(boolean canCreate) {
+        setCanCreate(canCreate);
+        return this;
+    }
+}
+

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.comments;
 
 import java.util.List;
+import java.util.Objects;
 
 public class Conversation {
 
@@ -45,6 +46,25 @@ public class Conversation {
     public Conversation canCreate(boolean canCreate) {
         setCanCreate(canCreate);
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Conversation)) {
+            return false;
+        }
+        Conversation that = (Conversation) o;
+        return isHasMore() == that.isHasMore() &&
+                isCanCreate() == that.isCanCreate() &&
+                getComments().equals(that.getComments());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getComments(), isHasMore(), isCanCreate());
     }
 }
 

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
@@ -26,7 +26,7 @@ public class Conversation {
         this.comments = comments;
     }
 
-    public boolean isHasMore() {
+    public boolean hasMore() {
         return hasMore;
     }
 
@@ -51,14 +51,14 @@ public class Conversation {
             return false;
         }
         Conversation that = (Conversation) o;
-        return isHasMore() == that.isHasMore() &&
+        return hasMore() == that.hasMore() &&
                 isCreatable() == that.isCreatable() &&
                 getComments().equals(that.getComments());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getComments(), isHasMore(), isCreatable());
+        return Objects.hash(getComments(), hasMore(), isCreatable());
     }
 }
 

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
@@ -9,17 +9,21 @@ public class Conversation {
     private boolean hasMore;
     private boolean canCreate;
 
+    public Conversation() {
+    }
+
+    public Conversation(List<Comment> comments, boolean hasMore, boolean canCreate) {
+        this.comments = comments;
+        this.hasMore = hasMore;
+        this.canCreate = canCreate;
+    }
+
     public List<Comment> getComments() {
         return comments;
     }
 
     public void setComments(List<Comment> comments) {
         this.comments = comments;
-    }
-
-    public Conversation comments(List<Comment> comments) {
-        setComments(comments);
-        return this;
     }
 
     public boolean isHasMore() {
@@ -30,22 +34,12 @@ public class Conversation {
         this.hasMore = hasMore;
     }
 
-    public Conversation hasMore(boolean hasMore) {
-        setHasMore(hasMore);
-        return this;
-    }
-
     public boolean isCanCreate() {
         return canCreate;
     }
 
     public void setCanCreate(boolean canCreate) {
         this.canCreate = canCreate;
-    }
-
-    public Conversation canCreate(boolean canCreate) {
-        setCanCreate(canCreate);
-        return this;
     }
 
     @Override

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/Conversation.java
@@ -7,15 +7,15 @@ public class Conversation {
 
     private List<Comment> comments;
     private boolean hasMore;
-    private boolean canCreate;
+    private boolean creatable;
 
     public Conversation() {
     }
 
-    public Conversation(List<Comment> comments, boolean hasMore, boolean canCreate) {
+    public Conversation(List<Comment> comments, boolean hasMore, boolean creatable) {
         this.comments = comments;
         this.hasMore = hasMore;
-        this.canCreate = canCreate;
+        this.creatable = creatable;
     }
 
     public List<Comment> getComments() {
@@ -34,12 +34,12 @@ public class Conversation {
         this.hasMore = hasMore;
     }
 
-    public boolean isCanCreate() {
-        return canCreate;
+    public boolean isCreatable() {
+        return creatable;
     }
 
-    public void setCanCreate(boolean canCreate) {
-        this.canCreate = canCreate;
+    public void setCreatable(boolean creatable) {
+        this.creatable = creatable;
     }
 
     @Override
@@ -52,13 +52,13 @@ public class Conversation {
         }
         Conversation that = (Conversation) o;
         return isHasMore() == that.isHasMore() &&
-                isCanCreate() == that.isCanCreate() &&
+                isCreatable() == that.isCreatable() &&
                 getComments().equals(that.getComments());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getComments(), isHasMore(), isCanCreate());
+        return Objects.hash(getComments(), isHasMore(), isCreatable());
     }
 }
 

--- a/apix-interface/src/main/java/eu/xenit/apix/comments/ICommentService.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/comments/ICommentService.java
@@ -1,0 +1,14 @@
+package eu.xenit.apix.comments;
+
+import eu.xenit.apix.data.NodeRef;
+
+public interface ICommentService {
+
+    NodeRef getTargetDocumentForComment(NodeRef commentNodeRef);
+    Conversation getComments(NodeRef targetNode, int skipCount, int pageSize);
+    Comment addNewComment(NodeRef targetNode, String content);
+    Comment updateComment(NodeRef targetCommentNode, String content);
+    Comment updateComment(NodeRef documentTargetNode, NodeRef commentTargetNode, String content);
+    void deleteComment(NodeRef targetCommentNode);
+    boolean canCreateComment(NodeRef targetDocumentNode);
+}

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -938,8 +938,9 @@ public class NodesWebscript1 extends ApixV1Webscript {
     }
 
     private void writeNotFoundResponse(WebScriptResponse response, NodeRef requestedNode) throws IOException {
-        logger.debug("Not Found: {}", requestedNode);
+        String message = String.format("Node Not Found: %s", requestedNode);
+        logger.debug(message);
         response.setStatus(404);
-        writeJsonResponse(response, "Node Not Found");
+        writeJsonResponse(response, message);
     }
 }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -8,6 +8,9 @@ import com.github.dynamicextensionsalfresco.webscripts.annotations.Transaction;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.UriVariable;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
+import eu.xenit.apix.comments.Comment;
+import eu.xenit.apix.comments.Conversation;
+import eu.xenit.apix.comments.ICommentService;
 import eu.xenit.apix.data.ContentInputStream;
 import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.data.QName;
@@ -44,10 +47,10 @@ import org.alfresco.model.ContentModel;
 import org.alfresco.repo.model.Repository;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
-import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.model.FileExistsException;
 import org.alfresco.service.cmr.repository.InvalidNodeRefException;
+import org.alfresco.service.cmr.security.PermissionService;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONArray;
@@ -79,6 +82,9 @@ public class NodesWebscript1 extends ApixV1Webscript {
 
     @Autowired
     IFileFolderService fileFolderService;
+
+    @Autowired
+    ICommentService commentService;
 
     @Autowired
     ServiceRegistry serviceRegistry;
@@ -651,6 +657,92 @@ public class NodesWebscript1 extends ApixV1Webscript {
 
     }
 
+    @ApiOperation(value = "Retrieves all comments for a given node")
+    @Uri(value = "/nodes/{space}/{store}/{guid}/comments", method = HttpMethod.GET)
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Success"),
+            @ApiResponse(code = 403, message = "Not Authorized"),
+            @ApiResponse(code = 404, message = "Not Found")
+    })
+    public void getComments(@UriVariable String space, @UriVariable String store, @UriVariable String guid,
+            @RequestParam int skipcount, @RequestParam int pagesize, WebScriptResponse response) throws IOException {
+        final NodeRef target = new NodeRef(space, store, guid);
+        if (nodeService.exists(target)) {
+            Conversation comments = commentService.getComments(target, skipcount, pagesize);
+            boolean canCreate = permissionService.hasPermission(target, PermissionService.CREATE_CHILDREN);
+            comments.setCanCreate(canCreate);
+            writeJsonResponse(response, comments);
+        } else {
+            writeNotFoundResponse(response, target);
+        }
+    }
+
+    @ApiOperation(value = "Appends a new comment to the given node.")
+    @Uri(value = "/nodes/{space}/{store}/{guid}/comments", method = HttpMethod.POST)
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Success"),
+            @ApiResponse(code = 403, message = "Not Authorized"),
+            @ApiResponse(code = 404, message = "Not Found")
+    })
+    public void postComment(@UriVariable String space, @UriVariable String store, @UriVariable String guid,
+            WebScriptRequest request, WebScriptResponse response) throws IOException {
+        final NodeRef target = new NodeRef(space, store, guid);
+        if (nodeService.exists(target)) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String content = objectMapper.readTree(request.getContent().getInputStream()).textValue();
+            Comment newComment = commentService.addNewComment(target, content);
+            writeJsonResponse(response, newComment);
+        } else {
+            writeNotFoundResponse(response, target);
+        }
+    }
+
+    @ApiOperation(value = "Updates a given comment on the given node.")
+    @Uri(value = "/nodes/{docspace}/{docstore}/{docguid}/comments/{commentspace}/{commentstore}/{commentguid}",
+            method = HttpMethod.POST)
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Success"),
+            @ApiResponse(code = 403, message = "Not Authorized"),
+            @ApiResponse(code = 404, message = "Not Found")
+    })
+    public void updateComment(@UriVariable String docspace, @UriVariable String docstore, @UriVariable String docguid,
+            @UriVariable String commentspace, @UriVariable String commentstore, @UriVariable String commentguid,
+            WebScriptRequest request, WebScriptResponse response) throws IOException {
+        final NodeRef targetDocument = new NodeRef(docspace, docspace, docspace);
+        final NodeRef targetComment = new NodeRef(commentspace, commentspace, commentguid);
+        if (nodeService.exists(targetComment)) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String content = objectMapper.readTree(request.getContent().getInputStream()).textValue();
+            Comment updatedComment = commentService.updateComment(targetComment, content);
+            response.setStatus(200);
+            writeJsonResponse(response, updatedComment);
+        } else {
+            writeNotFoundResponse(response, targetComment);
+        }
+    }
+
+    @ApiOperation(value = "Deletes a given comment on the given node.")
+    @Uri(value = "/nodes/{docspace}/{docstore}/{docguid}/comments/{commentspace}/{commentstore}/{commentguid}",
+            method = HttpMethod.POST)
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "Success"),
+            @ApiResponse(code = 403, message = "Not Authorized"),
+            @ApiResponse(code = 404, message = "Not Found")
+    })
+    public void deleteComment(@UriVariable String docspace, @UriVariable String docstore, @UriVariable String docguid,
+            @UriVariable String commentspace, @UriVariable String commentstore, @UriVariable String commentguid,
+            WebScriptRequest request, WebScriptResponse response) throws IOException {
+        final NodeRef targetDocument = new NodeRef(docspace, docspace, docspace);
+        final NodeRef targetComment = new NodeRef(commentspace, commentspace, commentguid);
+        if (nodeService.exists(targetComment)) {
+            commentService.deleteComment(targetComment);
+            response.setStatus(204);
+            writeJsonResponse(response, "Comment deleted");
+        } else {
+            writeNotFoundResponse(response, targetComment);
+        }
+    }
+
     @ApiOperation(value = "Downloads content file for given node")
     @Uri(value = "/nodes/{space}/{store}/{guid}/content", method = HttpMethod.GET)
     @ApiResponses({
@@ -847,5 +939,11 @@ public class NodesWebscript1 extends ApixV1Webscript {
         logger.debug("Not Authorized: ", exception);
         response.setStatus(403);
         writeJsonResponse(response, "Not authorised to execute this operation");
+    }
+
+    private void writeNotFoundResponse(WebScriptResponse response, NodeRef requestedNode) throws IOException {
+        logger.debug("Not Found: {}", requestedNode);
+        response.setStatus(404);
+        writeJsonResponse(response, "Node Not Found");
     }
 }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -668,10 +668,14 @@ public class NodesWebscript1 extends ApixV1Webscript {
             @RequestParam int skipcount, @RequestParam int pagesize, WebScriptResponse response) throws IOException {
         final NodeRef target = new NodeRef(space, store, guid);
         if (nodeService.exists(target)) {
-            Conversation comments = commentService.getComments(target, skipcount, pagesize);
-            boolean canCreate = permissionService.hasPermission(target, PermissionService.CREATE_CHILDREN);
-            comments.setCanCreate(canCreate);
-            writeJsonResponse(response, comments);
+            if(permissionService.hasPermission(target, PermissionService.READ)) {
+                Conversation comments = commentService.getComments(target, skipcount, pagesize);
+                boolean canCreate = permissionService.hasPermission(target, PermissionService.CREATE_CHILDREN);
+                comments.setCanCreate(canCreate);
+                writeJsonResponse(response, comments);
+            } else {
+                throw new AccessDeniedException("User does not have permission to read parent node");
+            }
         } else {
             writeNotFoundResponse(response, target);
         }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -688,7 +688,7 @@ public class NodesWebscript1 extends ApixV1Webscript {
             @ApiResponse(code = 403, message = "Not Authorized"),
             @ApiResponse(code = 404, message = "Not Found")
     })
-    public void postComment(@UriVariable String space, @UriVariable String store, @UriVariable String guid,
+    public void addComment(@UriVariable String space, @UriVariable String store, @UriVariable String guid,
             final Comment newComment, WebScriptRequest request, WebScriptResponse response) throws IOException {
         final NodeRef target = new NodeRef(space, store, guid);
         if (nodeService.exists(target)) {
@@ -723,7 +723,7 @@ public class NodesWebscript1 extends ApixV1Webscript {
     @Uri(value = "/nodes/{space}/{store}/{guid}/comment",
             method = HttpMethod.DELETE)
     @ApiResponses({
-            @ApiResponse(code = 204, message = "Success"),
+            @ApiResponse(code = 200, message = "Success"),
             @ApiResponse(code = 403, message = "Not Authorized"),
             @ApiResponse(code = 404, message = "Not Found")
     })
@@ -732,7 +732,7 @@ public class NodesWebscript1 extends ApixV1Webscript {
         final NodeRef targetComment = new NodeRef(space, store, guid);
         if (nodeService.exists(targetComment)) {
             commentService.deleteComment(targetComment);
-            response.setStatus(204);
+            response.setStatus(200);
             writeJsonResponse(response, "Comment deleted");
         } else {
             writeNotFoundResponse(response, targetComment);


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-298

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
This change adds a new interface to the java api and extends the rest api with 3 new endpoints
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
