### PR TITLE
ALFREDAPI-395 Change loglevels of PermissionService#hasPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 
 ### Changed
-
+* [ALFREDAPI-395](https://xenitsupport.jira/com/browse/ALFREDAPI-395): Change loglevels of PermissionSerivce#hasPermission
 
 ### Fixed
 * [ALFREDAPI-428](https://xenitsupport.jira.com/browse/ALFREDAPI-428): Replace PersonService#getPerson(String userName) with getPersonOrNull(String userName) to avoid creation of new users when getPerson is called with a nonexistent userName.

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/permissions/PermissionService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/permissions/PermissionService.java
@@ -155,7 +155,7 @@ public class PermissionService implements IPermissionService {
             case DENIED:
             case UNDETERMINED:
             default:
-                logger.warn("User {} does not have permission {} on node {} due to access status {}",
+                logger.debug("User {} does not have permission {} on node {} due to access status {}",
                         fullyAuthenticatedUser, permission, nodeRef, accessStatus);
                 return false;
         }


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-395
- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
