### PR TITLE
ALFREDAPI-438 Corrected permission that is checked in ancestors webscript + related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [ALFREDAPI-444](https://xenitsupport.jira.com/browse/ALFREDAPI-444): Updated and extended Create & Copy node integrationtests for "/nodes"
 
 ### Fixed
-
+* [ALFREDAPI-438](https://xenitsupport.jira.com/browse/ALFREDAPI-438): Fixed issue where wrong permissions would be checked when retrieving ancestors of a node
 
 ### Deleted
 * [ALFREDAPI-447](https://xenitsupport.jira.com/browse/ALFREDAPI-447): Removed unused class LuceneNodeVisitor. This does not affect functionality of the API.

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -449,7 +449,7 @@ public class NodeService implements INodeService {
         if (!nodeService.exists(nodeRef)) {
             throw new InvalidNodeRefException(String.format(nodeDoesNotExistMesage, nodeRef), nodeRef);
         }
-        if (permissionService.hasPermission(nodeRef, PermissionService.READ_PERMISSIONS) != AccessStatus.ALLOWED) {
+        if (permissionService.hasPermission(nodeRef, PermissionService.READ) != AccessStatus.ALLOWED) {
             throw new AccessDeniedException(String.format(accessDeniedMessage, nodeRef));
         }
 
@@ -460,7 +460,7 @@ public class NodeService implements INodeService {
             if (parentRef.equals(alfrescoRootRef)) {
                 break;
             }
-            if (permissionService.hasPermission(parentRef, PermissionService.READ_PERMISSIONS) != AccessStatus.ALLOWED) {
+            if (permissionService.hasPermission(parentRef, PermissionService.READ) != AccessStatus.ALLOWED) {
                 throw new AccessDeniedException(String.format(accessDeniedMessage, parentRef));
             }
             ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(parentRef);

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsBaseUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsBaseUnitTest.java
@@ -36,9 +36,9 @@ public abstract class AncestorsBaseUnitTest {
 
     protected PermissionService initPermissionServiceMock() {
         PermissionService permissionServiceMock = mock(PermissionService.class);
-        when(permissionServiceMock.hasPermission(eq(testNode1), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
-        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
-        when(permissionServiceMock.hasPermission(eq(testNode3), eq(PermissionService.READ_PERMISSIONS))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode1), eq(PermissionService.READ))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ))).thenReturn(AccessStatus.ALLOWED);
+        when(permissionServiceMock.hasPermission(eq(testNode3), eq(PermissionService.READ))).thenReturn(AccessStatus.ALLOWED);
 
         return permissionServiceMock;
     }

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromInaccessibleNodeUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromInaccessibleNodeUnitTest.java
@@ -35,7 +35,7 @@ public class AncestorsFromInaccessibleNodeUnitTest extends AncestorsBaseUnitTest
 
     protected PermissionService initPermissionServiceMock() {
         PermissionService permissionServiceMock = super.initPermissionServiceMock();
-        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS)))
+        when(permissionServiceMock.hasPermission(eq(testNode2), eq(PermissionService.READ)))
                 .thenReturn(AccessStatus.DENIED);
 
         return permissionServiceMock;

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromNodeUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/metadata/AncestorsFromNodeUnitTest.java
@@ -48,9 +48,9 @@ public class AncestorsFromNodeUnitTest extends AncestorsBaseUnitTest {
         Assert.assertEquals(2, ancestors.size());
         Assert.assertEquals(testNode2.toString(), ancestors.get(0).toString());
         Assert.assertEquals(testNode3.toString(), ancestors.get(1).toString());
-        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode1), eq(PermissionService.READ_PERMISSIONS));
-        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode2), eq(PermissionService.READ_PERMISSIONS));
-        verify(alfrescoPermissionService, times(0)).hasPermission(eq(testNode3), eq(PermissionService.READ_PERMISSIONS));
+        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode1), eq(PermissionService.READ));
+        verify(alfrescoPermissionService, times(1)).hasPermission(eq(testNode2), eq(PermissionService.READ));
+        verify(alfrescoPermissionService, times(0)).hasPermission(eq(testNode3), eq(PermissionService.READ));
         verify(alfrescoNodeService, times(1)).exists(eq(testNode1));
         verify(alfrescoNodeService, times(0)).exists(eq(testNode2));
         verify(alfrescoNodeService, times(0)).exists(eq(testNode3));


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-438

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [developer guide](https://github.com/xenit-eu/alfred-api/blob/master/developer-documentation)?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
