### PR TITLE
Alfredapi 466 Enable usage of -me- to retrieve current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 * [ALFREDAPI-463](https://xenitsupport.jira.com/browse/ALFREDAPI-463): Fix quotation marks in searches being improperly escaped. Search queries can now be escaped properly. E.g. \"Compas Format\" instead of \\\"Compas Format\\\" as was needed previously.
-* [ALFREDAPI-466](https://xenitsupport.jira.com/browse/ALFREDAPI-466): Add input normalization to `PersonService#GetPerson()`
+* [ALFREDAPI-466](https://xenitsupport.jira.com/browse/ALFREDAPI-466): Fix usage of the special `-me-` argument for the peopleAPI v1 & v2
 
 ### Deleted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 * [ALFREDAPI-463](https://xenitsupport.jira.com/browse/ALFREDAPI-463): Fix quotation marks in searches being improperly escaped. Search queries can now be escaped properly. E.g. \"Compas Format\" instead of \\\"Compas Format\\\" as was needed previously.
-
+* [ALFREDAPI-466](https://xenitsupport.jira.com/browse/ALFREDAPI-466): Add input normalization to `PersonService#GetPerson()`
 
 ### Deleted
 

--- a/apix-docker/61/debug-extension.docker-compose.yml
+++ b/apix-docker/61/debug-extension.docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - DEBUG=true
       - SHARE_HOST=alfresco-share
   alfresco-share:
-    image: alfresco/alfresco-share:6.1.1
+    image: hub.xenit.eu/public/alfresco-share-community:6.1
     ports:
       - 8090:8080
     environment:

--- a/apix-docker/62/debug-extension.docker-compose.yml
+++ b/apix-docker/62/debug-extension.docker-compose.yml
@@ -5,3 +5,11 @@ services:
       - 8000:8000
     environment:
       - DEBUG=true
+      - SHARE_HOST=alfresco-share
+  alfresco-share:
+    image: hub.xenit.eu/public/alfresco-share-community:6.1
+    ports:
+      - 8090:8080
+    environment:
+      - DEBUG=true
+      - ALFRESCO_HOST=alfresco-core

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/people/PeopleService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/people/PeopleService.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Service;
 @Primary
 public class PeopleService implements IPeopleService {
 
-    Logger logger = LoggerFactory.getLogger(PeopleService.class);
+    private static final Logger logger = LoggerFactory.getLogger(PeopleService.class);
 
     private ApixToAlfrescoConversion c;
     private PersonService alfrescoPersonService;
@@ -131,9 +131,10 @@ public class PeopleService implements IPeopleService {
         if (userName == null || userName.equals("")) {
             throw new IllegalArgumentException("Username cannot be null or empty");
         }
-        NodeRef personRef = c.apix(alfrescoPersonService.getPersonOrNull(userName));
+        String normalizedUserName = normalizeUserName(userName);
+        NodeRef personRef = c.apix(alfrescoPersonService.getPersonOrNull(normalizedUserName));
         if (personRef == null) {
-            throw new NoSuchElementException("User " + userName + " does not exist");
+            throw new NoSuchElementException("User " + normalizedUserName + " does not exist");
         }
         return GetPerson(personRef);
     }

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/PeopleTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/PeopleTest.java
@@ -104,6 +104,19 @@ public class PeopleTest extends BaseTest {
 
     }
 
+    @Test
+    public void testGetSelf() throws IOException {
+        final String userName = "-me-";
+        String url = createApixUrl("/people?userName=%s", userName);
+        HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
+        String result = EntityUtils.toString(httpResponse.getEntity());
+        Person person = new ObjectMapper().readValue(result, Person.class);
+        Assert.assertEquals("admin@alfresco.com", person.getEmailAddress());
+        Assert.assertEquals("admin", person.getUserName());
+        Assert.assertEquals("Administrator", person.getFirstName());
+        Assert.assertEquals("", person.getLastName());
+    }
+
     @After
     public void cleanUp() {
         this.removeMainTestFolder();

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v2/tests/PeopleTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v2/tests/PeopleTest.java
@@ -1,0 +1,27 @@
+package eu.xenit.apix.rest.v2.tests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.xenit.apix.people.Person;
+import java.io.IOException;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PeopleTest extends BaseTest {
+
+    @Test
+    public void testGetSelf() throws IOException {
+        final String userName = "-me-";
+        String url = createApixUrl("/people/%s", userName);
+        HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
+        String result = EntityUtils.toString(httpResponse.getEntity());
+        Person person = new ObjectMapper().readValue(result, Person.class);
+        Assert.assertEquals("admin@alfresco.com", person.getEmailAddress());
+        Assert.assertEquals("admin", person.getUserName());
+        Assert.assertEquals("Administrator", person.getFirstName());
+        Assert.assertEquals("", person.getLastName());
+    }
+
+}


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-466

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
