### PR TITLE
NYCSANSUP-34 Rerun site component retrieval upon accessdenied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 * [ALFREDAPI-463](https://xenitsupport.jira.com/browse/ALFREDAPI-463): Fix quotation marks in searches being improperly escaped. Search queries can now be escaped properly. E.g. \"Compas Format\" instead of \\\"Compas Format\\\" as was needed previously.
 * [ALFREDAPI-466](https://xenitsupport.jira.com/browse/ALFREDAPI-466): Fix usage of the special `-me-` argument for the peopleAPI v1 & v2
+* [ALFREDAPI-472](https://xenitsupport.jira.com/browse/ALFREDAPI-472): Fix AccessDeniedException in sitesService (primarily from Alfresco Records Management)
 
 ### Deleted
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/sites/SiteService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/sites/SiteService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.slf4j.Logger;
@@ -43,26 +44,39 @@ public class SiteService implements ISiteService {
         List<SiteInfo> userSites = siteService.listSites(userId);
 
         for (SiteInfo userSite : userSites) {
+
             NodeRef nodeRef = c.apix(userSite.getNodeRef());
             String shortName = userSite.getShortName();
             String title = userSite.getTitle();
             String description = userSite.getDescription();
             boolean isPublic = userSite.getIsPublic();
-            NodeRef documentLibrary = c.apix(siteService.getContainer(shortName, DOCUMENT_LIBRARY_COMPONENT));
-            NodeRef links = c.apix(siteService.getContainer(shortName, LINKS_COMPONENT));
-            NodeRef dataLists = c.apix(siteService.getContainer(shortName, DATA_LISTS_COMPONENT));
-            NodeRef wiki = c.apix(siteService.getContainer(shortName, WIKI_COMPONENT));
-            NodeRef discussions = c.apix(siteService.getContainer(shortName, DISCUSSIONS_COMPONENT));
-            Map<String, NodeRef> componentsMap = new HashMap<>();
-            componentsMap.put(DOCUMENT_LIBRARY_COMPONENT, documentLibrary);
-            componentsMap.put(LINKS_COMPONENT, links);
-            componentsMap.put(DATA_LISTS_COMPONENT, dataLists);
-            componentsMap.put(WIKI_COMPONENT, wiki);
-            componentsMap.put(DISCUSSIONS_COMPONENT, discussions);
-
-            apixSites.add(new Site(nodeRef, shortName, title, description, isPublic, componentsMap));
+            // Wrapping method for NYCSANSUP-34:
+            // Alfresco-RM blocked retrieval of components due to its onw permission model
+            // this caused the entire call to fail.
+            try {
+                Map<String, NodeRef> componentsMap = getSiteComponents(siteService, shortName);
+                apixSites.add(new Site(nodeRef, shortName, title, description, isPublic, componentsMap));
+            } catch (AccessDeniedException accessDeniedException) {
+                logger.warn("User {} does not have access to a site component for site {} according to exception.",
+                        userId, shortName, accessDeniedException);
+            }
         }
-
         return apixSites;
+    }
+
+    private Map<String, NodeRef> getSiteComponents(org.alfresco.service.cmr.site.SiteService siteService,
+            String siteShortname) {
+        Map<String, NodeRef> componentsMap = new HashMap<>();
+        NodeRef documentLibrary = c.apix(siteService.getContainer(siteShortname, DOCUMENT_LIBRARY_COMPONENT));
+        NodeRef links = c.apix(siteService.getContainer(siteShortname, LINKS_COMPONENT));
+        NodeRef dataLists = c.apix(siteService.getContainer(siteShortname, DATA_LISTS_COMPONENT));
+        NodeRef wiki = c.apix(siteService.getContainer(siteShortname, WIKI_COMPONENT));
+        NodeRef discussions = c.apix(siteService.getContainer(siteShortname, DISCUSSIONS_COMPONENT));
+        componentsMap.put(DOCUMENT_LIBRARY_COMPONENT, documentLibrary);
+        componentsMap.put(LINKS_COMPONENT, links);
+        componentsMap.put(DATA_LISTS_COMPONENT, dataLists);
+        componentsMap.put(WIKI_COMPONENT, wiki);
+        componentsMap.put(DISCUSSIONS_COMPONENT, discussions);
+        return componentsMap;
     }
 }


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/NYCSANSUP-34

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
