### PR TITLE
ALFREDAPI-184 Improve graceful handling of bad input in ConfigurationWebscript1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 * [ALFREDAPI-463](https://xenitsupport.jira.com/browse/ALFREDAPI-463): Fix quotation marks in searches being improperly escaped. Search queries can now be escaped properly. E.g. \"Compas Format\" instead of \\\"Compas Format\\\" as was needed previously.
 * [ALFREDAPI-466](https://xenitsupport.jira.com/browse/ALFREDAPI-466): Fix usage of the special `-me-` argument for the peopleAPI v1 & v2
+* [ALFREDAPI-184](https://xenitsupport.jira.com/browse/ALFREDAPI-184): Improve graceful handling of bad input in ConfigurationWebscript1
 
 ### Deleted
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/configuration/ConfigurationServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/configuration/ConfigurationServiceImpl.java
@@ -19,6 +19,7 @@ import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.node.NodeMetadata;
 import eu.xenit.apix.rest.v1.configuration.ConfigurationWebscript1;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,8 +67,15 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         logger.debug("Looking up directory {} inside datadictionary {}", searchDirectory, rootFolder);
 
         NodeRef searchDirectoryRef = rootFolder;
-        if (!searchDirectory.isEmpty()) {
-            searchDirectoryRef = fileFolderService.getChildNodeRef(rootFolder, searchDirectoryParts);
+        try {
+            if (!searchDirectory.isEmpty()) {
+                searchDirectoryRef = fileFolderService.getChildNodeRef(rootFolder, searchDirectoryParts);
+            }
+        } catch (InvalidArgumentException invalidArgumentException) {
+            // Wrapping exception in generic IllegalArgumentException since the original exception is an alfresco dependency,
+            // which we do not want to propagate into the interface (This would be required to have the webscript declare
+            // a catch clause)
+            throw new IllegalArgumentException(invalidArgumentException.getMessage(), invalidArgumentException);
         }
 
         logger.debug("Search directory: {}", searchDirectoryRef.getValue());

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/configuration/ConfigurationWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/configuration/ConfigurationWebscript1.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Authentication;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.AuthenticationType;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.ExceptionHandler;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.HttpMethod;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.RequestParam;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
+import com.sun.star.auth.InvalidArgumentException;
 import eu.xenit.apix.configuration.ConfigurationFileFlags;
 import eu.xenit.apix.configuration.ConfigurationService;
 import eu.xenit.apix.configuration.Configurations;
@@ -27,6 +29,8 @@ import java.io.Writer;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
@@ -37,6 +41,8 @@ import org.springframework.stereotype.Component;
 @Authentication(AuthenticationType.USER)
 @Component("eu.xenit.apix.rest.v1.configuration.ConfigurationWebscript1")
 public class ConfigurationWebscript1 extends ApixV1Webscript {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfigurationWebscript1.class);
 
     @Autowired
     IFileFolderService fileFolderService;
@@ -96,5 +102,12 @@ public class ConfigurationWebscript1 extends ApixV1Webscript {
         writer.write(");");
         writer.flush();
         writer.close();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    private void writeBadRequestResponse(IllegalArgumentException exception, WebScriptResponse response)  throws IOException{
+        log.debug("Bad input;", exception);
+        response.setStatus(400);
+        writeJsonResponse(response, exception.getMessage());
     }
 }


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-184

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
