### PR TITLE
ALFREDAPI-473: Integration tests are again run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ALFREDAPI-463](https://xenitsupport.jira.com/browse/ALFREDAPI-463): Fix quotation marks in searches being improperly escaped. Search queries can now be escaped properly. E.g. \"Compas Format\" instead of \\\"Compas Format\\\" as was needed previously.
 * [ALFREDAPI-466](https://xenitsupport.jira.com/browse/ALFREDAPI-466): Fix usage of the special `-me-` argument for the peopleAPI v1 & v2
 * [ALFREDAPI-472](https://xenitsupport.jira.com/browse/ALFREDAPI-472): Fix AccessDeniedException in sitesService (primarily from Alfresco Records Management)
+* [ALFREDAPI-473](https://xenitsupport.jira.com/browse/ALFREDAPI-473): Integration tests are again run
 
 ### Deleted
 

--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -140,7 +140,7 @@ public class Version {
         // apix-impl/src/integration-test/java/eu/xenit/apix/tests/ApixImplBundleFilter.java
         // to find which integration tests need to run, so when changing it, change it there too.
         bnd(
-                'Export-Package': 'eu.xenit.apix.*',
+                'Export-Package': 'eu.xenit.apix.*; -split-package:=merge-first',
                 'Include-Resource': includeResource(configurations.compile),
                 'Bundle-ClassPath': bundleClassPath(configurations.compile),
                 'Bundle-SymbolicName': "${project.group}.${project.name}",

--- a/apix-integrationtests/build.gradle
+++ b/apix-integrationtests/build.gradle
@@ -20,6 +20,7 @@ subprojects {
     sourceSets {
         main {
             java {
+                srcDirs '../src/main/java'
                 // This is needed because client side, these dependencies are not really provided
                 runtimeClasspath += configurations.compileOnly
             }
@@ -39,7 +40,7 @@ allprojects {
         integrationJar
         compileOnly.extendsFrom(integrationJar)
     }
-    
+
     dependencies {
         compileOnly project(":apix-rest-v1")
         compileOnly project(":apix-interface")


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-473

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
