### PR TITLE
Alfredapi 296

### DIFF
--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/AspectService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/AspectService.java
@@ -9,6 +9,7 @@ import eu.xenit.apix.dictionary.aspects.IAspectService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +47,10 @@ public class AspectService implements IAspectService {
             properties.add(c.apix((qName)));
         }
         ret.setProperties(properties);
+        List<QName> mandatoryAspects = aspectDef.getDefaultAspects(true).stream()
+                .map(aspectDefinition -> c.apix(aspectDefinition.getName()))
+                .collect(Collectors.toList());
+        ret.setMandatoryAspects(mandatoryAspects);
         return ret;
 
     }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/AspectService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/AspectService.java
@@ -47,7 +47,7 @@ public class AspectService implements IAspectService {
             properties.add(c.apix((qName)));
         }
         ret.setProperties(properties);
-        List<QName> mandatoryAspects = aspectDef.getDefaultAspects(true).stream()
+        List<QName> mandatoryAspects = aspectDef.getDefaultAspects().stream()
                 .map(aspectDefinition -> c.apix(aspectDefinition.getName()))
                 .collect(Collectors.toList());
         ret.setMandatoryAspects(mandatoryAspects);

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/TypeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/TypeService.java
@@ -9,6 +9,7 @@ import eu.xenit.apix.dictionary.types.Types;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.namespace.InvalidQNameException;
 import org.alfresco.service.namespace.NamespaceException;
@@ -66,6 +67,10 @@ public class TypeService implements ITypeService {
             properties.add(c.apix((qName)));
         }
         ret.setProperties(properties);
+        List<QName> mandatoryAspects = typeDef.getDefaultAspects(true).stream()
+                .map(aspectDefinition -> c.apix(aspectDefinition.getName()))
+                .collect(Collectors.toList());
+        ret.setMandatoryAspects(mandatoryAspects);
         return ret;
 
     }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/TypeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/dictionary/TypeService.java
@@ -67,7 +67,7 @@ public class TypeService implements ITypeService {
             properties.add(c.apix((qName)));
         }
         ret.setProperties(properties);
-        List<QName> mandatoryAspects = typeDef.getDefaultAspects(true).stream()
+        List<QName> mandatoryAspects = typeDef.getDefaultAspects().stream()
                 .map(aspectDefinition -> c.apix(aspectDefinition.getName()))
                 .collect(Collectors.toList());
         ret.setMandatoryAspects(mandatoryAspects);

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/DictionaryTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/DictionaryTest.java
@@ -1,5 +1,14 @@
 package eu.xenit.apix.rest.v1.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
 import org.alfresco.repo.dictionary.DictionaryDAO;
 import org.alfresco.repo.dictionary.M2Model;
 import org.alfresco.repo.dictionary.M2Type;
@@ -16,13 +25,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.io.IOException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 public class DictionaryTest extends BaseTest {
 
@@ -51,7 +53,8 @@ public class DictionaryTest extends BaseTest {
         assertEquals(cmNamespace, name);
     }
 
-    private void executeDictionaryTypeTest(String dictionaryType, String shortName, String longName, String mandatoryAspect)
+    private void executeDictionaryTypeTest(String dictionaryType, String shortName, String longName,
+            String mandatoryAspect)
             throws IOException, JSONException {
         String baseUrl = makeAlfrescoBaseurlAdmin() + "/apix/v1/dictionary/" + dictionaryType + "/";
 
@@ -82,7 +85,8 @@ public class DictionaryTest extends BaseTest {
 
     @Test
     public void testTypeDefinitionGet() throws IOException, JSONException {
-        executeDictionaryTypeTest("types", "cm:cmobject", "{http://www.alfresco.org/model/content/1.0}cmobject", "{http://www.alfresco.org/model/content/1.0}auditable");
+        executeDictionaryTypeTest("types", "cm:cmobject", "{http://www.alfresco.org/model/content/1.0}cmobject",
+                "{http://www.alfresco.org/model/content/1.0}auditable");
     }
 
 
@@ -119,7 +123,9 @@ public class DictionaryTest extends BaseTest {
 
     @Test
     public void testAspectDefinitionGet() throws IOException, JSONException {
-        executeDictionaryTypeTest("aspects", "cm:complianceable", "{http://www.alfresco.org/model/content/1.0}complianceable", "{http://www.alfresco.org/model/content/1.0}auditable");
+        executeDictionaryTypeTest("aspects", "cm:complianceable",
+                "{http://www.alfresco.org/model/content/1.0}complianceable",
+                "{http://www.alfresco.org/model/content/1.0}auditable");
     }
 
     @Autowired
@@ -150,23 +156,21 @@ public class DictionaryTest extends BaseTest {
         assertEquals(404, httpResponse.getStatusLine().getStatusCode());
     }
 
-    public void assertMandatoryAspects(JSONObject jsonObject, String expectedMandatoryAspect) {try {
-        JSONArray jsonArray = jsonObject.getJSONArray("mandatoryAspects");
-        boolean aspectFound = false;
-        int jsonArrayLength = jsonArray.length();
-        int arrayIndex = 0;
-        while (!aspectFound & arrayIndex < jsonArrayLength) {
-            String element = (String) jsonArray.get(arrayIndex);
-            if (expectedMandatoryAspect.equals(element)) {
-                aspectFound = true;
+    public void assertMandatoryAspects(JSONObject jsonObject, String expectedMandatoryAspect) {
+        try {
+            JSONArray jsonArray = jsonObject.getJSONArray("mandatoryAspects");
+            boolean aspectFound = false;
+            for (int arrayIndex = 0; !aspectFound && arrayIndex < jsonArray.length(); arrayIndex++) {
+                String element = jsonArray.getString(arrayIndex);
+                if (expectedMandatoryAspect.equals(element)) {
+                    aspectFound = true;
+                }
             }
-            arrayIndex++;
+            assertTrue("Retrieved Definition does not contain expected mandatory aspect.", aspectFound);
+        } catch (JSONException jsonException) {
+            logger.error("Caught JSONException for DictionaryTest", jsonException);
+            fail();
         }
-        assertTrue("Retrieved Definition does not contain expected mandatory aspect.", aspectFound);
-    } catch (JSONException jsonException) {
-        logger.error("Caught JSONException for DictionaryTest", jsonException);
-        fail();
-    }
 
     }
 

--- a/apix-interface/src/main/java/eu/xenit/apix/dictionary/aspects/AspectDefinition.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/dictionary/aspects/AspectDefinition.java
@@ -1,7 +1,6 @@
 package eu.xenit.apix.dictionary.aspects;
 
 import eu.xenit.apix.data.QName;
-
 import java.util.List;
 
 public class AspectDefinition {
@@ -11,6 +10,7 @@ public class AspectDefinition {
     private String title;
     private String description;
     private List<QName> properties;
+    private List<QName> mandatoryAspects;
 
     public QName getName() {
         return name;
@@ -50,5 +50,13 @@ public class AspectDefinition {
 
     public void setProperties(List<QName> properties) {
         this.properties = properties;
+    }
+
+    public List<QName> getMandatoryAspects() {
+        return mandatoryAspects;
+    }
+
+    public void setMandatoryAspects(List<QName> mandatoryAspects) {
+        this.mandatoryAspects = mandatoryAspects;
     }
 }

--- a/apix-interface/src/main/java/eu/xenit/apix/dictionary/types/TypeDefinition.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/dictionary/types/TypeDefinition.java
@@ -14,6 +14,7 @@ public class TypeDefinition {
     private String title;
     private String description;
     private List<QName> properties;
+    private List<QName> mandatoryAspects;
 
     public TypeDefinition() {
     }
@@ -68,5 +69,13 @@ public class TypeDefinition {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public List<QName> getMandatoryAspects() {
+        return mandatoryAspects;
+    }
+
+    public void setMandatoryAspects(List<QName> mandatoryAspects) {
+        this.mandatoryAspects = mandatoryAspects;
     }
 }


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-296

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.

Pr will add a list of qnames for all aspects that are mandatory for the requested type or aspect definition.
