### PR TITLE
ALFREDAPI-484 adjust logging on tests from info to debug

### DIFF
--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/staging/tests/WorkflowTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/staging/tests/WorkflowTest.java
@@ -128,7 +128,7 @@ public class WorkflowTest extends StagingBaseTest {
 
         try (CloseableHttpResponse response = httpclient.execute(httppost)) {
             String jsonString = EntityUtils.toString(response.getEntity());
-            logger.info(" Result: " + jsonString + " ");
+            logger.debug(" Result: " + jsonString + " ");
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }
@@ -169,7 +169,7 @@ public class WorkflowTest extends StagingBaseTest {
 
         try (CloseableHttpResponse response = httpclient.execute(httppost)) {
             String jsonString = EntityUtils.toString(response.getEntity());
-            logger.info(" Result: " + jsonString + " ");
+            logger.debug(" Result: " + jsonString + " ");
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
     }

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -40,7 +40,7 @@ public class AllNodeInfoTest extends RestV1BaseTest {
     public void testGetAllNodeInfo() throws IOException {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.TESTFILE_NAME), "admin", "admin");
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
         for (int i = 0; i < 20; i++) {
             logger.error("For the request of testGetAllNodeInfo");
             logger.error(url);
@@ -48,7 +48,7 @@ public class AllNodeInfoTest extends RestV1BaseTest {
 
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
-        logger.info(" Result: " + result);
+        logger.debug(" Result: " + result);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
@@ -125,7 +125,7 @@ public class AllNodeInfoTest extends RestV1BaseTest {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url =
                 makeAlfrescoBaseurl(RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS) + "/apix/v1/nodes/nodeInfo";
-        logger.info("url: {}", url);
+        logger.debug("url: {}", url);
         String jsonString = json(
                 "{" +
                         "\"noderefs\": [\"" +

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/AllNodeInfoTest.java
@@ -41,11 +41,6 @@ public class AllNodeInfoTest extends RestV1BaseTest {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.TESTFILE_NAME), "admin", "admin");
         logger.debug(" URL: " + url);
-        for (int i = 0; i < 20; i++) {
-            logger.error("For the request of testGetAllNodeInfo");
-            logger.error(url);
-        }
-
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
         logger.debug(" Result: " + result);
@@ -67,11 +62,11 @@ public class AllNodeInfoTest extends RestV1BaseTest {
                         "\"" +
                         "]}"));
 
-        logger.error("jsonString: " + jsonString);
+        logger.debug("jsonString: " + jsonString);
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v1/nodes/nodeInfo";
-        logger.error("url: " + url);
+        logger.debug("url: " + url);
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(new StringEntity(jsonString));
 
@@ -89,7 +84,7 @@ public class AllNodeInfoTest extends RestV1BaseTest {
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v1/nodes/nodeInfo";
-        logger.error("url: " + url);
+        logger.debug("url: " + url);
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(new StringEntity(jsonString));
 
@@ -108,7 +103,7 @@ public class AllNodeInfoTest extends RestV1BaseTest {
                 + "]}");
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final String url = makeAlfrescoBaseurl(RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS) + "/apix/v1/nodes/nodeInfo";
-        logger.error("url: " + url);
+        logger.debug("url: " + url);
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(new StringEntity(jsonString));
 

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/BulkTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/BulkTest.java
@@ -86,15 +86,15 @@ public abstract class BulkTest extends RestV1BaseTest {
                         "get"))));
         try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
             String result = EntityUtils.toString(response.getEntity());
-            logger.info(" Result bulk metadata get: " + result);
+            logger.debug(" Result bulk metadata get: " + result);
             assertEquals(200, response.getStatusLine().getStatusCode());
             JSONArray jsonArray = new JSONArray(result);
-            logger.info(" json object 0: " + jsonArray.get(0));
-            logger.info(" json object 1: " + jsonArray.get(1));
+            logger.debug(" json object 0: " + jsonArray.get(0));
+            logger.debug(" json object 1: " + jsonArray.get(1));
             JSONObject jsonObject0 = (JSONObject) jsonArray.get(0);
             JSONObject jsonObject1 = (JSONObject) jsonArray.get(1);
-            logger.info(" statusCode object 0: " + jsonObjectGetStringFromInt(jsonObject0, "statusCode"));
-            logger.info(" statusCode object 1: " + jsonObjectGetStringFromInt(jsonObject1, "statusCode"));
+            logger.debug(" statusCode object 0: " + jsonObjectGetStringFromInt(jsonObject0, "statusCode"));
+            logger.debug(" statusCode object 1: " + jsonObjectGetStringFromInt(jsonObject1, "statusCode"));
             assertEquals("200", jsonObjectGetStringFromInt(jsonObject0, "statusCode"));
             assertEquals("200", jsonObjectGetStringFromInt(jsonObject1, "statusCode"));
         }
@@ -122,18 +122,18 @@ public abstract class BulkTest extends RestV1BaseTest {
                 firstGetUrl, secondGetUrl, thirdGetUrl))));
         try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
             String result = EntityUtils.toString(response.getEntity());
-            logger.info(" Result bulk metadata get: " + result);
+            logger.debug(" Result bulk metadata get: " + result);
             assertEquals(200, response.getStatusLine().getStatusCode());
             JSONArray jsonArray = new JSONArray(result);
-            logger.info(" json object 0: " + jsonArray.get(0));
-            logger.info(" json object 1: " + jsonArray.get(1));
-            logger.info(" json object 2: " + jsonArray.get(2));
+            logger.debug(" json object 0: " + jsonArray.get(0));
+            logger.debug(" json object 1: " + jsonArray.get(1));
+            logger.debug(" json object 2: " + jsonArray.get(2));
             JSONObject jsonObject0 = (JSONObject) jsonArray.get(0);
             JSONObject jsonObject1 = (JSONObject) jsonArray.get(1);
             JSONObject jsonObject2 = (JSONObject) jsonArray.get(2);
-            logger.info(" statusCode object 0: " + jsonObjectGetStringFromInt(jsonObject0, "statusCode"));
-            logger.info(" statusCode object 1: " + jsonObjectGetStringFromInt(jsonObject1, "statusCode"));
-            logger.info(" statusCode object 2: " + jsonObjectGetStringFromInt(jsonObject2, "statusCode"));
+            logger.debug(" statusCode object 0: " + jsonObjectGetStringFromInt(jsonObject0, "statusCode"));
+            logger.debug(" statusCode object 1: " + jsonObjectGetStringFromInt(jsonObject1, "statusCode"));
+            logger.debug(" statusCode object 2: " + jsonObjectGetStringFromInt(jsonObject2, "statusCode"));
             assertEquals("200", jsonObjectGetStringFromInt(jsonObject0, "statusCode"));
             assertEquals("200", jsonObjectGetStringFromInt(jsonObject1, "statusCode"));
             assertEquals("200", jsonObjectGetStringFromInt(jsonObject2, "statusCode"));
@@ -176,7 +176,7 @@ public abstract class BulkTest extends RestV1BaseTest {
                     public Object execute() throws Throwable {
                         try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
                             String result = EntityUtils.toString(response.getEntity());
-                            logger.info(" Result bulk metadata post: " + result);
+                            logger.debug(" Result bulk metadata post: " + result);
                             assertEquals(200, response.getStatusLine().getStatusCode());
                             assertTrue(alfrescoNodeService
                                     .hasAspect(new org.alfresco.service.cmr.repository.NodeRef(
@@ -206,7 +206,7 @@ public abstract class BulkTest extends RestV1BaseTest {
                     public Object execute() throws Throwable {
                         try (CloseableHttpResponse response = httpclient.execute(httpPost2)) {
                             String result = EntityUtils.toString(response.getEntity());
-                            logger.info(" Result bulk metadata post: " + result);
+                            logger.debug(" Result bulk metadata post: " + result);
                             assertEquals(200, response.getStatusLine().getStatusCode());
                             assertEquals("newName", alfrescoNodeService
                                     .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
@@ -228,7 +228,7 @@ public abstract class BulkTest extends RestV1BaseTest {
                     public Object execute() throws Throwable {
                         try (CloseableHttpResponse response = httpclient.execute(httpPost3)) {
                             String result = EntityUtils.toString(response.getEntity());
-                            logger.info(" Result bulk metadata post: " + result);
+                            logger.debug(" Result bulk metadata post: " + result);
                             assertEquals(200, response.getStatusLine().getStatusCode());
                             assertNotEquals("newName", alfrescoNodeService
                                     .getProperty(new org.alfresco.service.cmr.repository.NodeRef(
@@ -363,7 +363,7 @@ public abstract class BulkTest extends RestV1BaseTest {
                     public Object execute() throws Throwable {
                         try (CloseableHttpResponse response = httpclient.execute(httpPost2)) {
                             String result = EntityUtils.toString(response.getEntity());
-                            logger.info(" Result bulk delete post: " + result);
+                            logger.debug(" Result bulk delete post: " + result);
                             assertEquals(200, response.getStatusLine().getStatusCode());
                             assertFalse(alfrescoNodeService
                                     .exists(new org.alfresco.service.cmr.repository.NodeRef(

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/MetadataTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/MetadataTest.java
@@ -72,10 +72,10 @@ public class MetadataTest extends RestV1BaseTest {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.TESTFILE_NAME), "/metadata?alf_ticket=" + authenticationService.getCurrentTicket(),
                 "admin", "admin");
-        logger.info("URL: " + url);
+        logger.debug("URL: " + url);
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
 
-        logger.info(EntityUtils.toString(httpResponse.getEntity()));
+        logger.debug(EntityUtils.toString(httpResponse.getEntity()));
         assertEquals(200, httpResponse.getStatusLine().getStatusCode());
     }
 
@@ -84,10 +84,10 @@ public class MetadataTest extends RestV1BaseTest {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.NOUSERRIGHTS_FILE_NAME), "/metadata",
                 RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS);
-        logger.info("URL: " + url);
+        logger.debug("URL: " + url);
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
 
-        logger.info(EntityUtils.toString(httpResponse.getEntity()));
+        logger.debug(EntityUtils.toString(httpResponse.getEntity()));
         assertEquals(403, httpResponse.getStatusLine().getStatusCode());
     }
 
@@ -95,7 +95,7 @@ public class MetadataTest extends RestV1BaseTest {
     public void testMetadataPost() throws IOException, JSONException {
         final HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.TESTFILE_NAME), "/metadata", "admin", "admin");
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
 
         assertFalse(this.nodeService.hasAspect(new org.alfresco.service.cmr.repository.NodeRef(initializedNodeRefs.get(
                 RestV1BaseTest.TESTFILE_NAME).getValue()),
@@ -114,7 +114,7 @@ public class MetadataTest extends RestV1BaseTest {
         final NodeRef testNodeRef;
         try (CloseableHttpResponse response = httpclient.execute(httppost)) {
             String jsonString = EntityUtils.toString(response.getEntity());
-            logger.info(" Result: " + jsonString + " ");
+            logger.debug(" Result: " + jsonString + " ");
             assertEquals(200, response.getStatusLine().getStatusCode());
 
             JSONObject jsonObject = new JSONObject(jsonString);
@@ -140,7 +140,7 @@ public class MetadataTest extends RestV1BaseTest {
     public void testMetadataPostReturnsAccesDenied() throws IOException, JSONException {
         final HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.NOUSERRIGHTS_FILE_NAME), "/metadata", RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS);
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
 
         CloseableHttpClient httpclient = HttpClients.createDefault();
         HttpPost httppost = new HttpPost(url);
@@ -155,14 +155,14 @@ public class MetadataTest extends RestV1BaseTest {
 
         try (CloseableHttpResponse response = httpclient.execute(httppost)) {
             String jsonString = EntityUtils.toString(response.getEntity());
-            logger.info(" Result: " + jsonString + " ");
+            logger.debug(" Result: " + jsonString + " ");
             assertEquals(403, response.getStatusLine().getStatusCode());
         }
     }
 
     private String getUrl(NodeRef nodeRef) {
         final String url = makeNodesUrl(nodeRef, "admin", "admin");
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
         return url;
     }
 
@@ -230,10 +230,10 @@ public class MetadataTest extends RestV1BaseTest {
     public void testMetadataShortGet() throws IOException {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.TESTFILE_NAME).getGuid(), "/metadata", "admin", "admin");
-        logger.info("URL: " + url);
+        logger.debug("URL: " + url);
         HttpResponse httpResponse = Request.Get(url).execute().returnResponse();
 
-        logger.info(EntityUtils.toString(httpResponse.getEntity()));
+        logger.debug(EntityUtils.toString(httpResponse.getEntity()));
         assertEquals(200, httpResponse.getStatusLine().getStatusCode());
     }
 

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/MoveNodeTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/MoveNodeTest.java
@@ -73,7 +73,7 @@ public class MoveNodeTest extends RestV1BaseTest {
                 }, false, true);
 
         final String url = this.makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.TESTFILE_NAME), "/parent", "admin", "admin");
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
 
         doPut(url, null, "{\"parent\":\"%s\"}", mainTestFolder.toString());
 
@@ -97,7 +97,7 @@ public class MoveNodeTest extends RestV1BaseTest {
         final NodeRef mainTestFolder = primaryParentAssocTestFolder.getTarget();
 
         final String url = this.makeNodesUrl(initializedNodeRefs.get(RestV1BaseTest.NOUSERRIGHTS_FILE_NAME), "/parent", RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS);
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
         final CloseableHttpClient httpClient = HttpClients.createDefault();
         HttpPut httpPut = new HttpPut(url);
         httpPut.setEntity(new StringEntity(String.format("{\"parent\":\"%s\"}", mainTestFolder.toString())));

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/temp/UploadFileTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/temp/UploadFileTest.java
@@ -72,7 +72,7 @@ public class UploadFileTest extends RestV1BaseTest {
     @Test
     public void testUploadFile() throws IOException {
         String url = createUrl(null, null);
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
         HttpEntity entity = createHttpEntity(parentNodeRef.toString(), LOCAL_TESTFILE_NAME);
         try (CloseableHttpResponse response = doPost(url, entity)) {
             String resultString = EntityUtils.toString(response.getEntity());
@@ -93,7 +93,7 @@ public class UploadFileTest extends RestV1BaseTest {
     @Test
     public void testUploadFileResultsInAccessDenied() throws IOException {
         String url = createUrl(RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS);
-        logger.info(">>>>> URL: " + url);
+        logger.debug(">>>>> URL: " + url);
         HttpEntity entity = createHttpEntity(initNodeRefArray.get(RestV1BaseTest.NOUSERRIGHTS_FILE_NAME).toString(), LOCAL_TESTFILE_NAME);
         try (CloseableHttpResponse response = doPost(url, entity)) {
             String resultString = EntityUtils.toString(response.getEntity());

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
@@ -40,11 +40,6 @@ public class AllNodeInfoTest extends RestV2BaseTest {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV2BaseTest.TESTFILE_NAME), "admin", "admin");
         logger.debug(" URL: " + url);
-        for (int i = 0; i < 20; i++) {
-            logger.error("For the request of testGetAllNodeInfo");
-            logger.error(url);
-        }
-
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
         logger.debug(" Result: " + result);
@@ -66,11 +61,11 @@ public class AllNodeInfoTest extends RestV2BaseTest {
                         "\"" +
                         "]}"));
 
-        logger.error("jsonString: " + jsonString);
+        logger.debug("jsonString: " + jsonString);
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v2/nodes/nodeInfo";
-        logger.error("url: " + url);
+        logger.debug("url: " + url);
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(new StringEntity(jsonString));
 
@@ -88,7 +83,7 @@ public class AllNodeInfoTest extends RestV2BaseTest {
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final String url = makeAlfrescoBaseurl("admin", "admin") + "/apix/v2/nodes/nodeInfo";
-        logger.error("url: " + url);
+        logger.debug("url: " + url);
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(new StringEntity(jsonString));
 
@@ -136,7 +131,7 @@ public class AllNodeInfoTest extends RestV2BaseTest {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final String url = makeAlfrescoBaseurl(
                 RestV1BaseTest.USERWITHOUTRIGHTS, RestV1BaseTest.USERWITHOUTRIGHTS) + "/apix/v1/nodes/nodeInfo";
-        logger.error("url: " + url);
+        logger.debug("url: " + url);
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(new StringEntity(jsonString));
 

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v2/tests/AllNodeInfoTest.java
@@ -39,7 +39,7 @@ public class AllNodeInfoTest extends RestV2BaseTest {
     public void testGetAllNodeInfo() throws IOException {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url = makeNodesUrl(initializedNodeRefs.get(RestV2BaseTest.TESTFILE_NAME), "admin", "admin");
-        logger.info(" URL: " + url);
+        logger.debug(" URL: " + url);
         for (int i = 0; i < 20; i++) {
             logger.error("For the request of testGetAllNodeInfo");
             logger.error(url);
@@ -47,7 +47,7 @@ public class AllNodeInfoTest extends RestV2BaseTest {
 
         HttpResponse response = Request.Get(url).execute().returnResponse();
         String result = EntityUtils.toString(response.getEntity());
-        logger.info(" Result: " + result);
+        logger.debug(" Result: " + result);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
@@ -102,7 +102,7 @@ public class AllNodeInfoTest extends RestV2BaseTest {
         HashMap<String, NodeRef> initializedNodeRefs = init();
         String url =
                 makeAlfrescoBaseurl(RestV2BaseTest.USERWITHOUTRIGHTS, RestV2BaseTest.USERWITHOUTRIGHTS) + "/apix/v2/nodes/nodeInfo";
-        logger.info("url: {}", url);
+        logger.debug("url: {}", url);
         String jsonString = json(
                 "{" +
                         "\"noderefs\": [\"" +

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/search/SearchServiceTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/search/SearchServiceTest.java
@@ -192,7 +192,7 @@ abstract public class SearchServiceTest extends BaseTest {
                         query.setQuery(node);
                         SearchQueryResult result = searchService.query(query);
 
-                        logger.info("Total: " + result.getTotalResultCount());
+                        logger.debug("Total: " + result.getTotalResultCount());
                         Assert.assertEquals(2, result.getTotalResultCount());
                         return null;
                     }

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/groups/GroupsWebscript.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/groups/GroupsWebscript.java
@@ -90,7 +90,7 @@ public class GroupsWebscript extends ApixV2Webscript {
         // duplicates is going to be cheaper than unnecessarily invoking all of Alfresco's internal safety checking
         List<Person> linkedUsers = personService.GetUsersOfGroup(name, true);
 
-        logger.info("Setting new list of users for {}", name);
+        logger.debug("Setting new list of users for {}", name);
         // error handling, if {name} isn't a group
         if (linkedUsers == null) {
             giveNoGroup404(webScriptResponse, name);
@@ -117,7 +117,7 @@ public class GroupsWebscript extends ApixV2Webscript {
         // duplicates is going to be cheaper than unnecessarily invoking all of Alfresco's internal safety checking
         List<Group> linkedGroups = personService.GetSubgroupsInGroup(name, true);
 
-        logger.info("Setting new list of subgroups for {}", name);
+        logger.debug("Setting new list of subgroups for {}", name);
         // error handling, if {name} isn't a group
         if (linkedGroups == null) {
             giveNoGroup404(webScriptResponse, name);


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-ALFREDAPI-484

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [N/A] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [N/A] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [N/A] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
