### PR TITLE
ALFREDAPI-378 replace serviceregistry calls for facetlabeldisplayhandlerregistry and solrfacethelperserviceregistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+* [ALFREDAPI-378](https://xenitsupport.jira.com/browse/ALFREDAPI-378): Replace depricated calls to serviceregistry
 
 ### Deleted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 
 ### Changed
-* [ALFREDAPI-378](https://xenitsupport.jira.com/browse/ALFREDAPI-378): Replace depricated calls to serviceregistry
+* [ALFREDAPI-378](https://xenitsupport.jira.com/browse/ALFREDAPI-378): Replace deprecated calls to serviceregistry
 
 ### Deleted
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -86,6 +86,23 @@ public class SearchFacetsServiceImpl implements SearchFacetsService, BeanFactory
         facetLabelDisplayHandlerRegistry = (FacetLabelDisplayHandlerRegistry) beanFactory.getBean(facetLabelDisplayHandlerRegistryBeanName);
     }
 
+    public FacetLabelDisplayHandlerRegistry getFacetLabelDisplayHandlerRegistry() {
+        return facetLabelDisplayHandlerRegistry;
+    }
+
+    public void setFacetLabelDisplayHandlerRegistry(
+            FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry) {
+        this.facetLabelDisplayHandlerRegistry = facetLabelDisplayHandlerRegistry;
+    }
+
+    public SolrFacetHelper getSolrFacetHelper() {
+        return solrFacetHelper;
+    }
+
+    public void setSolrFacetHelper(SolrFacetHelper solrFacetHelper) {
+        this.solrFacetHelper = solrFacetHelper;
+    }
+
     public List<SolrFacetProperties> filterFacets(SearchQuery.FacetOptions opts, List<SolrFacetProperties> facets) {
         List<SolrFacetProperties> enabledFacets = new ArrayList<>();
         for (SolrFacetProperties facet : facets) {

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -38,7 +38,6 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -48,49 +47,24 @@ import org.springframework.stereotype.Component;
 public class SearchFacetsServiceImpl implements SearchFacetsService {
 
     private static final Logger logger = LoggerFactory.getLogger(SearchFacetsServiceImpl.class);
-
-    @Autowired
     private FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry;
-    @Autowired
     private SolrFacetHelper solrFacetHelper;
     private DictionaryService dictionaryService;
     private NodeService nodeService;
-    @Autowired
     private SolrFacetService facetService;
-    @Autowired
     private ITranslationService translationService;
 
     // This file might give inspection error due to being 5.x specific.
     // Intellij can't handle this file being reused in different libs.
     @Autowired
-    public SearchFacetsServiceImpl(ServiceRegistry serviceRegistry) {
+    public SearchFacetsServiceImpl(ServiceRegistry serviceRegistry, SolrFacetService solrFacetsService,
+            ITranslationService translationService) {
+        facetService = solrFacetsService;
+        this.translationService = translationService;
+        facetLabelDisplayHandlerRegistry = serviceRegistry.getFacetLabelDisplayHandlerRegistry();
+        solrFacetHelper = serviceRegistry.getSolrFacetHelper();
         dictionaryService = serviceRegistry.getDictionaryService();
         nodeService = serviceRegistry.getNodeService();
-    }
-
-//    @Override
-//    public void afterPropertiesSet() throws Exception {
-//        final String solrFacetHelperBeanName = "facet.solrFacetHelper";
-//        solrFacetHelper = (SolrFacetHelper) beanFactory.getBean(solrFacetHelperBeanName);
-//        final String facetLabelDisplayHandlerRegistryBeanName = "facet.facetLabelDisplayHandlerRegistry";
-//        facetLabelDisplayHandlerRegistry = (FacetLabelDisplayHandlerRegistry) beanFactory.getBean(facetLabelDisplayHandlerRegistryBeanName);
-//    }
-
-    public FacetLabelDisplayHandlerRegistry getFacetLabelDisplayHandlerRegistry() {
-        return facetLabelDisplayHandlerRegistry;
-    }
-
-    public void setFacetLabelDisplayHandlerRegistry(
-            FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry) {
-        this.facetLabelDisplayHandlerRegistry = facetLabelDisplayHandlerRegistry;
-    }
-
-    public SolrFacetHelper getSolrFacetHelper() {
-        return solrFacetHelper;
-    }
-
-    public void setSolrFacetHelper(SolrFacetHelper solrFacetHelper) {
-        this.solrFacetHelper = solrFacetHelper;
     }
 
     public List<SolrFacetProperties> filterFacets(SearchQuery.FacetOptions opts, List<SolrFacetProperties> facets) {

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -38,9 +38,6 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -48,15 +45,13 @@ import org.springframework.stereotype.Component;
 // Note: To *temporarily* get working syntax highlighting and IDE features in this file: change the root
 // build.gradle to have alfresco_4_version = "5.0.d" rather than "4.2.f". Change it back before committing.
 @Component
-public class SearchFacetsServiceImpl implements SearchFacetsService, BeanFactoryAware, InitializingBean {
+public class SearchFacetsServiceImpl implements SearchFacetsService {
 
     private static final Logger logger = LoggerFactory.getLogger(SearchFacetsServiceImpl.class);
 
-    // Beanfactory added to replace alfresco's ServiceRegistry.getFacetLabelDisplayHandlerRegistry
-    // (Due to alfresco planning to remove the class from the public api)
-    private BeanFactory beanFactory;
-
+    @Autowired
     private FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry;
+    @Autowired
     private SolrFacetHelper solrFacetHelper;
     private DictionaryService dictionaryService;
     private NodeService nodeService;
@@ -73,18 +68,13 @@ public class SearchFacetsServiceImpl implements SearchFacetsService, BeanFactory
         nodeService = serviceRegistry.getNodeService();
     }
 
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        this.beanFactory = beanFactory;
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        final String solrFacetHelperBeanName = "facet.solrFacetHelper";
-        solrFacetHelper = (SolrFacetHelper) beanFactory.getBean(solrFacetHelperBeanName);
-        final String facetLabelDisplayHandlerRegistryBeanName = "facet.facetLabelDisplayHandlerRegistry";
-        facetLabelDisplayHandlerRegistry = (FacetLabelDisplayHandlerRegistry) beanFactory.getBean(facetLabelDisplayHandlerRegistryBeanName);
-    }
+//    @Override
+//    public void afterPropertiesSet() throws Exception {
+//        final String solrFacetHelperBeanName = "facet.solrFacetHelper";
+//        solrFacetHelper = (SolrFacetHelper) beanFactory.getBean(solrFacetHelperBeanName);
+//        final String facetLabelDisplayHandlerRegistryBeanName = "facet.facetLabelDisplayHandlerRegistry";
+//        facetLabelDisplayHandlerRegistry = (FacetLabelDisplayHandlerRegistry) beanFactory.getBean(facetLabelDisplayHandlerRegistryBeanName);
+//    }
 
     public FacetLabelDisplayHandlerRegistry getFacetLabelDisplayHandlerRegistry() {
         return facetLabelDisplayHandlerRegistry;

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
 
 import eu.xenit.apix.alfresco.search.SearchFacetsService;
 import eu.xenit.apix.alfresco.search.SearchFacetsServiceImpl;
@@ -16,10 +15,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import eu.xenit.apix.translation.ITranslationService;
 import org.alfresco.repo.dictionary.constraint.ListOfValuesConstraint;
 import org.alfresco.repo.search.impl.solr.facet.SolrFacetHelper;
-import org.alfresco.repo.search.impl.solr.facet.SolrFacetService;
 import org.alfresco.repo.search.impl.solr.facet.handler.FacetLabelDisplayHandlerRegistry;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.dictionary.ConstraintDefinition;
@@ -33,6 +30,7 @@ import org.alfresco.service.cmr.search.SearchParameters.FieldFacet;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
 import org.junit.Test;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class SearchFacetServiceUnitTest {
@@ -48,12 +46,9 @@ public class SearchFacetServiceUnitTest {
         ServiceRegistry serviceRegistryMock = mock(ServiceRegistry.class);
 
         SolrFacetHelper solrFacetHelperMock = mock(SolrFacetHelper.class);
-        when(serviceRegistryMock.getSolrFacetHelper()).thenReturn(solrFacetHelperMock);
 
         FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistryStub =
                 new FacetLabelDisplayHandlerRegistry();
-        when(serviceRegistryMock.getFacetLabelDisplayHandlerRegistry())
-                .thenReturn(facetLabelDisplayHandlerRegistryStub);
 
         DataTypeDefinition textDataTypeDef = mock(DataTypeDefinition.class);
         when(textDataTypeDef.getName()).thenReturn(DataTypeDefinition.TEXT);
@@ -97,6 +92,8 @@ public class SearchFacetServiceUnitTest {
         when(serviceRegistryMock.getDictionaryService()).thenReturn(dictionaryServiceMock);
 
         searchFacetsService = new SearchFacetsServiceImpl(serviceRegistryMock);
+        ((SearchFacetsServiceImpl) searchFacetsService).setSolrFacetHelper(solrFacetHelperMock);
+        ((SearchFacetsServiceImpl) searchFacetsService).setFacetLabelDisplayHandlerRegistry(facetLabelDisplayHandlerRegistryStub);
 
         facetOptionsMock = mock(FacetOptions.class);
         when(facetOptionsMock.isEnabled()).thenReturn(true);

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
@@ -11,12 +11,14 @@ import eu.xenit.apix.alfresco.search.SearchFacetsServiceImpl;
 import eu.xenit.apix.search.FacetSearchResult;
 import eu.xenit.apix.search.FacetSearchResult.FacetValue;
 import eu.xenit.apix.search.SearchQuery.FacetOptions;
+import eu.xenit.apix.translation.ITranslationService;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 import org.alfresco.repo.dictionary.constraint.ListOfValuesConstraint;
 import org.alfresco.repo.search.impl.solr.facet.SolrFacetHelper;
+import org.alfresco.repo.search.impl.solr.facet.SolrFacetService;
 import org.alfresco.repo.search.impl.solr.facet.handler.FacetLabelDisplayHandlerRegistry;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.dictionary.ConstraintDefinition;
@@ -30,7 +32,6 @@ import org.alfresco.service.cmr.search.SearchParameters.FieldFacet;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class SearchFacetServiceUnitTest {
@@ -90,10 +91,10 @@ public class SearchFacetServiceUnitTest {
         when(dictionaryServiceMock.getProperty(documentStatusQName)).thenReturn(documentStatusPropDefMock);
 
         when(serviceRegistryMock.getDictionaryService()).thenReturn(dictionaryServiceMock);
-
-        searchFacetsService = new SearchFacetsServiceImpl(serviceRegistryMock);
-        ((SearchFacetsServiceImpl) searchFacetsService).setSolrFacetHelper(solrFacetHelperMock);
-        ((SearchFacetsServiceImpl) searchFacetsService).setFacetLabelDisplayHandlerRegistry(facetLabelDisplayHandlerRegistryStub);
+        when(serviceRegistryMock.getSolrFacetHelper()).thenReturn(solrFacetHelperMock);
+        when(serviceRegistryMock.getFacetLabelDisplayHandlerRegistry()).thenReturn(facetLabelDisplayHandlerRegistryStub);
+        searchFacetsService = new SearchFacetsServiceImpl(serviceRegistryMock, mock(SolrFacetService.class), mock(
+                ITranslationService.class));
 
         facetOptionsMock = mock(FacetOptions.class);
         when(facetOptionsMock.isEnabled()).thenReturn(true);


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-378

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
