### PR TITLE
ALFREDAPI-408: Remove dep from apix-impl on apix-rest

### DIFF
--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -90,9 +90,7 @@ allprojects {
 
     dependencies {
         compile(project(":apix-interface"))
-        compile(project(":apix-rest-v1")) {
-            exclude group: 'org.alfresco'
-        }
+
         alfrescoProvided group: 'org.alfresco', name: 'alfresco-repository', version: alfresco_version
         alfrescoProvided group: 'org.alfresco', name: 'alfresco-remote-api', version: alfresco_version
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/configuration/ConfigurationServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/configuration/ConfigurationServiceImpl.java
@@ -17,7 +17,6 @@ import eu.xenit.apix.filefolder.IFileFolderService;
 import eu.xenit.apix.node.ChildParentAssociation;
 import eu.xenit.apix.node.INodeService;
 import eu.xenit.apix.node.NodeMetadata;
-import eu.xenit.apix.rest.v1.configuration.ConfigurationWebscript1;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
 import org.slf4j.Logger;
@@ -44,7 +43,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
     private static final String QNAME_FOLDER = TYPE_FOLDER.toString();
     private static final QName QNAME_NAME = new QName(PROP_NAME.toString());
-    Logger logger = LoggerFactory.getLogger(ConfigurationWebscript1.class);
+    Logger logger = LoggerFactory.getLogger(ConfigurationServiceImpl.class);
 
     @Autowired
     IFileFolderService fileFolderService;


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-408

[ALFREDAPI-408]

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.


[ALFREDAPI-408]: https://xenitsupport.jira.com/browse/ALFREDAPI-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ