### PR TITLE
XENOPS-891 update wars for 52, 62 & 70 to latest hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+* [XENOPS-891](https://xenitsupport.jira.com/browse/XENOPS-891): update docker images and wars to latest hotfix for 52, 62 & 70
 * [ALFREDAPI-378](https://xenitsupport.jira.com/browse/ALFREDAPI-378): Replace deprecated calls to serviceregistry
 
 ### Deleted

--- a/apix-docker/52/build.gradle
+++ b/apix-docker/52/build.gradle
@@ -1,10 +1,11 @@
 dependencies {
-    baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.2.5@war"
+    baseAlfrescoWar platform('org.alfresco:alfresco-platform-enterprise:5.2.7.12')
+    baseAlfrescoWar "org.alfresco:alfresco-platform-enterprise@war"
     if (!ci.isCi()) {
         alfrescoAmp(group: 'eu.xenit.care4alf', name: 'care4alf-5x', version: "${care4alfVersion}", ext: 'amp')
     }
 }
 
 dockerAlfresco {
-    baseImage = "hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.2.5"
+    baseImage = "hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.2.7.12"
 }

--- a/apix-docker/61/build.gradle
+++ b/apix-docker/61/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
-    baseAlfrescoWar 'org.alfresco:content-services:6.1.1@war'
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:6.1.1.11")
+    baseAlfrescoWar 'org.alfresco:content-services@war'
     // Fix for https://github.com/xenit-eu/dynamic-extensions-for-alfresco#alfresco-61---wrong-version-of-commons-annotations-used
     alfrescoAmp(group: 'eu.xenit.alfresco', name: 'alfresco-hotfix-MNT-20557', version: '1.0.1', ext: 'amp')
     if (!ci.isCi()) {
@@ -8,5 +9,5 @@ dependencies {
 }
 
 dockerAlfresco {
-    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.1'
+    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.1.1.11'
 }

--- a/apix-docker/61/build.gradle
+++ b/apix-docker/61/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:6.1.1.11")
+    baseAlfrescoWar platform("org.alfresco:content-services:6.1.1.3")
     baseAlfrescoWar 'org.alfresco:content-services@war'
     // Fix for https://github.com/xenit-eu/dynamic-extensions-for-alfresco#alfresco-61---wrong-version-of-commons-annotations-used
     alfrescoAmp(group: 'eu.xenit.alfresco', name: 'alfresco-hotfix-MNT-20557', version: '1.0.1', ext: 'amp')
@@ -9,5 +9,5 @@ dependencies {
 }
 
 dockerAlfresco {
-    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.1.1.11'
+    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.1.1.3'
 }

--- a/apix-docker/62/build.gradle
+++ b/apix-docker/62/build.gradle
@@ -1,9 +1,10 @@
 dependencies {
-    baseAlfrescoWar 'org.alfresco:content-services:6.2.1@war'
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:6.2.2.19")
+    baseAlfrescoWar 'org.alfresco:content-services:6.2.2.19@war'
     // Fix for https://github.com/xenit-eu/dynamic-extensions-for-alfresco#alfresco-61---wrong-version-of-commons-annotations-used
     alfrescoAmp(group: 'eu.xenit.alfresco', name: 'alfresco-hotfix-MNT-20557', version: '1.0.2', ext: 'amp')
 }
 
 dockerAlfresco {
-    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.1'
+    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2.19'
 }

--- a/apix-docker/70/build.gradle
+++ b/apix-docker/70/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.0.0")
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.0.1.13")
     baseAlfrescoWar 'org.alfresco:content-services@war'
 }
 
 dockerAlfresco {
-    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.0'
+    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.1.13'
 }

--- a/apix-docker/70/build.gradle
+++ b/apix-docker/70/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.0.1.13")
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.0.1.3")
     baseAlfrescoWar 'org.alfresco:content-services@war'
 }
 
 dockerAlfresco {
-    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.1.13'
+    baseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.1.3'
 }

--- a/apix-docker/build.gradle
+++ b/apix-docker/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'eu.xenit.docker-alfresco' version '5.0.0' apply false
-    id 'eu.xenit.docker-compose' version '5.0.0' apply false
+    id 'eu.xenit.docker-alfresco' version '5.0.6' apply false
+    id 'eu.xenit.docker-compose' version '5.0.6' apply false
     id 'be.vbgn.ci-detect' version '0.1.0' apply false
 }
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/XENOPS-891

Changes to 61 are temporary since the latest hotfix for this version has an issue (documented separately). I've pinned the war & docker image to the previous version.

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [N/A] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [N/A] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
