### PR TITLE
ALFREDAPI-494

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+* [ALFREDAPI-494](https://xenitsupport.jira.com/browse/ALFREDAPI-494): Unused properties of json request body are now ignored
 
 ### Deleted
 

--- a/apix-interface/src/main/java/eu/xenit/apix/search/SearchQuery.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/search/SearchQuery.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.search;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import eu.xenit.apix.data.QName;
 import eu.xenit.apix.data.StoreRef;
@@ -22,6 +23,7 @@ import java.util.Objects;
  * consistency: Options related to consistency. Is defaulted by eventual consistency.
  * highlight: Options related to term hit highlighting, similar to the Alfresco 5.2.4 API
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SearchQuery {
 
     @ApiModelProperty(required = true)

--- a/apix-interface/src/main/java/eu/xenit/apix/translation/PropertyTranslationValue.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/translation/PropertyTranslationValue.java
@@ -1,5 +1,6 @@
 package eu.xenit.apix.translation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import eu.xenit.apix.data.QName;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -9,6 +10,7 @@ import java.util.Map;
  * Datastructure that represents the translations of a single property its values for a single language. values: The map
  * from property key to translation.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertyTranslationValue extends TranslationValue {
 
     @ApiModelProperty(dataType = "Map[string,string]")

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/bulk/BulkRequest.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/bulk/BulkRequest.java
@@ -1,11 +1,13 @@
 package eu.xenit.apix.rest.v1.bulk;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Represents a single request in a bulk requests call Created by kenneth on 18.03.16.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BulkRequest {
 
     @ApiModelProperty(required = true, allowableValues = "get,put,post,delete")

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/bulk/BulkSubResult.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/bulk/BulkSubResult.java
@@ -1,5 +1,6 @@
 package eu.xenit.apix.rest.v1.bulk;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
@@ -8,6 +9,7 @@ import java.util.Map;
 /**
  * Created by kenneth on 06.06.16.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BulkSubResult {
 
     @ApiModelProperty(value = "The HTTP status code of the sub call", example = "200")

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/ChangeParentOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/ChangeParentOptions.java
@@ -1,12 +1,14 @@
 package eu.xenit.apix.rest.v1.nodes;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Created by Michiel Huygen on 12/05/2016.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 class ChangeParentOptions {
 
     @ApiModelProperty(required = true)

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateAssociationOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateAssociationOptions.java
@@ -1,5 +1,6 @@
 package eu.xenit.apix.rest.v1.nodes;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.data.QName;
 import io.swagger.annotations.ApiModelProperty;
@@ -7,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Created by Michiel Huygen on 23/05/2016.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateAssociationOptions {
 
     @ApiModelProperty(required = true)

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.rest.v1.nodes;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xenit.apix.data.QName;
@@ -13,6 +14,7 @@ import org.alfresco.model.ContentModel;
 /**
  * Created by Michiel Huygen on 12/05/2016.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateNodeOptions {
 
     public static final QName PROP_NAME_QNAME = new QName(ContentModel.PROP_NAME.toString());

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/InheritFromParent.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/InheritFromParent.java
@@ -1,9 +1,11 @@
 package eu.xenit.apix.rest.v1.nodes;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 class InheritFromParent {
 
     @ApiModelProperty(required = true)

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/workingcopies/CheckoutBody.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/workingcopies/CheckoutBody.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.rest.v1.workingcopies;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import eu.xenit.apix.data.NodeRef;
 import io.swagger.annotations.ApiModelProperty;
@@ -8,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Created by Michiel Huygen on 12/05/2016.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 class CheckoutBody {
 
     @ApiModelProperty(required = true)

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/groups/SetSubgroupOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/groups/SetSubgroupOptions.java
@@ -1,9 +1,11 @@
 package eu.xenit.apix.rest.v2.groups;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 class SetSubgroupOptions {
 
     @ApiModelProperty(required = true)

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/groups/SetUsersInGroupOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v2/groups/SetUsersInGroupOptions.java
@@ -1,9 +1,11 @@
 package eu.xenit.apix.rest.v2.groups;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 class SetUsersInGroupOptions {
 
     @ApiModelProperty(required = true)


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-494

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
