### PR TITLE
Alfredapi 492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 3.0.2 (Unreleased)
 
 ### Added
+* [ALFREDAPI-492](https://xenitsupport.jira.com/browse/ALFREDAPI-492): /v1/nodes POST enpoint now accepts aspects to add/remove
 
 ### Changed
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -582,7 +582,8 @@ public class NodeService implements INodeService {
 
     @Override
     public eu.xenit.apix.data.NodeRef createNode(eu.xenit.apix.data.NodeRef parent,
-            Map<eu.xenit.apix.data.QName, String[]> properties, eu.xenit.apix.data.QName type,
+            Map<eu.xenit.apix.data.QName, String[]> properties, eu.xenit.apix.data.QName[] aspectsToAdd,
+            eu.xenit.apix.data.QName[] aspectsToRemove, eu.xenit.apix.data.QName type,
             eu.xenit.apix.data.ContentData contentData) {
         String[] names = properties.get(c.apix(ContentModel.PROP_NAME));
         if (names == null || names.length == 0) {
@@ -599,6 +600,11 @@ public class NodeService implements INodeService {
                     QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, QName.createValidLocalName(name)),
                     c.alfresco(type),
                     toAlfrescoPropertyMap(properties));
+            
+            MetadataChanges aspects = new MetadataChanges();
+            aspects.setAspectsToAdd(aspectsToAdd);
+            aspects.setAspectsToRemove(aspectsToRemove);
+            setMetadata(c.apix(result.getChildRef()), aspects);
 
             if (contentData != null) {
                 this.nodeService.setProperty(result.getChildRef(), ContentModel.PROP_CONTENT, c.alfresco(contentData));

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -582,6 +582,13 @@ public class NodeService implements INodeService {
 
     @Override
     public eu.xenit.apix.data.NodeRef createNode(eu.xenit.apix.data.NodeRef parent,
+            Map<eu.xenit.apix.data.QName, String[]> properties, eu.xenit.apix.data.QName type,
+            eu.xenit.apix.data.ContentData contentData) {
+        return createNode(parent, properties, null, null, type, contentData);
+    }
+
+    @Override
+    public eu.xenit.apix.data.NodeRef createNode(eu.xenit.apix.data.NodeRef parent,
             Map<eu.xenit.apix.data.QName, String[]> properties, eu.xenit.apix.data.QName[] aspectsToAdd,
             eu.xenit.apix.data.QName[] aspectsToRemove, eu.xenit.apix.data.QName type,
             eu.xenit.apix.data.ContentData contentData) {

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/CopyNodeTest.java
@@ -4,8 +4,8 @@ import eu.xenit.apix.alfresco.ApixToAlfrescoConversion;
 import eu.xenit.apix.data.NodeRef;
 import eu.xenit.apix.data.QName;
 import eu.xenit.apix.node.INodeService;
-import java.util.HashMap;
 import eu.xenit.apix.rest.v1.nodes.CreateNodeOptions;
+import java.util.HashMap;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.service.transaction.TransactionService;
@@ -50,6 +50,26 @@ public class CopyNodeTest extends NodesBaseTest {
     public void testCopyFileNode() {
         CreateNodeOptions createNodeOptions = getCreateNodeOptions(mainTestFolder, null,
                 null, null , copyFromFile);
+        NodeRef newRef = transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> {
+                    return doPostNodes(createNodeOptions, HttpStatus.SC_OK, null,null);
+                }, false, true);
+        checkCreatedNode(newRef, createNodeOptions);
+    }
+
+    @Test
+    public void testCopyFileNodeWithAspectsToRemove() {
+        transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> {
+                    serviceRegistry.getNodeService().addAspect(c.alfresco(copyFromFile), ContentModel.ASPECT_TEMPORARY, new HashMap<>());
+                    return null;
+                }, false, true);
+
+        QName[] aspectsToRemove = new QName[1];
+        aspectsToRemove[0] = c.apix(ContentModel.ASPECT_TEMPORARY);
+        CreateNodeOptions createNodeOptions = getCreateNodeOptions(mainTestFolder, null,
+                null, null, null, aspectsToRemove, copyFromFile);
+
         NodeRef newRef = transactionService.getRetryingTransactionHelper()
                 .doInTransaction(() -> {
                     return doPostNodes(createNodeOptions, HttpStatus.SC_OK, null,null);

--- a/apix-interface/src/main/java/eu/xenit/apix/data/QName.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/data/QName.java
@@ -1,6 +1,7 @@
 package eu.xenit.apix.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -9,6 +10,11 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public class QName {
 
     private String value;
+
+    @JsonCreator
+    public QName() {
+
+    }
 
     @JsonCreator
     public QName(String s) {

--- a/apix-interface/src/main/java/eu/xenit/apix/node/INodeService.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/node/INodeService.java
@@ -141,11 +141,14 @@ public interface INodeService {
      *
      * @param parent      The parent node of the new node.
      * @param properties  list of properties to add to node.
+     * @param aspectsToAdd  list of aspects to add to node.
+     * @param aspectsToRemove  list of aspects to remove from node.
      * @param type        The type of the node.
      * @param contentData can contain returned result of function createContent (or null).
      * @return The noderef of the new node.
      */
-    NodeRef createNode(NodeRef parent, Map<QName, String[]> properties, QName type, ContentData contentData);
+    NodeRef createNode(NodeRef parent, Map<QName, String[]> properties, QName[] aspectsToAdd, QName[] aspectsToRemove,
+            QName type, ContentData contentData);
 
     /**
      * Convenience method to create a node giving the type, the list of properties,

--- a/apix-interface/src/main/java/eu/xenit/apix/node/INodeService.java
+++ b/apix-interface/src/main/java/eu/xenit/apix/node/INodeService.java
@@ -141,6 +141,18 @@ public interface INodeService {
      *
      * @param parent      The parent node of the new node.
      * @param properties  list of properties to add to node.
+     * @param type        The type of the node.
+     * @param contentData can contain returned result of function createContent (or null).
+     * @return The noderef of the new node.
+     */
+    NodeRef createNode(NodeRef parent, Map<QName, String[]> properties, QName type, ContentData contentData);
+
+    /**
+     * Creation of a node giving the list of properties as well as the type. To be used when using a custom type has
+     * required properties.
+     *
+     * @param parent      The parent node of the new node.
+     * @param properties  list of properties to add to node.
      * @param aspectsToAdd  list of aspects to add to node.
      * @param aspectsToRemove  list of aspects to remove from node.
      * @param type        The type of the node.

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/CreateNodeOptions.java
@@ -21,6 +21,9 @@ public class CreateNodeOptions {
     public String name;
     public String type;
     public Map<QName, String[]> properties;
+
+    public QName[] aspectsToAdd;
+    public QName[] aspectsToRemove;
     public String copyFrom;
     private ObjectMapper mapper = new ObjectMapper();
 
@@ -29,6 +32,8 @@ public class CreateNodeOptions {
             @JsonProperty("name") String name,
             @JsonProperty("type") String type,
             @JsonProperty("properties") Map<QName, String[]> properties,
+            @JsonProperty("aspectsToAdd") QName[] aspectsToAdd,
+            @JsonProperty("aspectsToRemove") QName[] aspectsToRemove,
             @JsonProperty("copyFrom") String copyFrom) throws IOException {
         this.parent = parent;
         this.name = name;
@@ -40,6 +45,21 @@ public class CreateNodeOptions {
         if ((name != null && !this.properties.containsKey(PROP_NAME_QNAME))) {
             this.properties.put(PROP_NAME_QNAME, new String[]{name});
         }
+
+        if (aspectsToAdd == null) {
+            this.aspectsToAdd = new QName[0];
+        }
+        else {
+            this.aspectsToAdd = aspectsToAdd;
+        }
+
+        if (aspectsToRemove == null) {
+            this.aspectsToRemove = new QName[0];
+        }
+        else {
+            this.aspectsToRemove = aspectsToRemove;
+        }
+
         this.copyFrom = copyFrom;
     }
 
@@ -57,6 +77,14 @@ public class CreateNodeOptions {
 
     public Map<QName, String[]> getProperties() {
         return properties;
+    }
+
+    public QName[] getAspectsToAdd() {
+        return aspectsToAdd;
+    }
+
+    public QName[] getAspectsToRemove() {
+        return aspectsToRemove;
     }
 
     public String getCopyFrom() {

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -587,7 +587,7 @@ public class NodesWebscript1 extends ApixV1Webscript {
         notes = "Example of POST body:\n"
                 + "\n"
                 + "```\n"
-                + "POST /apix/v1/nodes/nodeInfo\n"
+                + "POST /apix/v1/nodes\n"
                 + "{\n"
                 + "\"parent\" : \"workspace://SpacesStore/d5dac928-e581-4507-9be7-9a2416adc318\", \n"
                 + "\"name\" : \"mydocument.txt\", \n"

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -583,7 +583,37 @@ public class NodesWebscript1 extends ApixV1Webscript {
         }
     }
 
-    @ApiOperation("Creates or copies a node")
+    @ApiOperation(value = "Creates or copies a node",
+        notes = "Example of POST body:\n"
+                + "\n"
+                + "```\n"
+                + "POST /apix/v1/nodes/nodeInfo\n"
+                + "{\n"
+                + "\"parent\" : \"workspace://SpacesStore/d5dac928-e581-4507-9be7-9a2416adc318\", \n"
+                + "\"name\" : \"mydocument.txt\", \n"
+                + "\"type\" : \"{http://www.alfresco.org/model/content/1.0}content\", \n"
+                + "\"properties\" : {\n"
+                + "      \"{namespace}property1\": [\n"
+                + "        \"string\"\n"
+                + "      ],\n"
+                + "      \"{namespace}property2\": [\n"
+                + "        \"string\"\n"
+                + "      ],\n"
+                + "      \"{namespace}property3\": [\n"
+                + "        \"string\"\n"
+                + "      ]\n"
+                + "}, \n"
+                + "\"aspectsToAdd\" : [\n"
+                + "      \"{namespace}aspect1\"\n"
+                + "], \n"
+                + "\"aspectsToRemove\" : [\n"
+                + "      \"{namespace}aspect1\"\n"
+                + "], \n"
+                + "\"copyFrom\" : \"workspace://SpacesStore/f0d15919-3841-4170-807f-b81d2ebdeb80\", \n"
+                + "}\n"
+                + "```"
+                + "\n"
+                + "\"aspectsToRemove\" is only relevant when copying a node.\n")
     @Uri(value = "/nodes", method = HttpMethod.POST)
     @ApiResponses({@ApiResponse(code = 200, message = "Success", response = NodeInfo.class),
             @ApiResponse(code = 403, message = "Not Authorized")})

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/nodes/NodesWebscript1.java
@@ -26,7 +26,6 @@ import eu.xenit.apix.node.NodeMetadata;
 import eu.xenit.apix.permissions.IPermissionService;
 import eu.xenit.apix.permissions.NodePermission;
 import eu.xenit.apix.permissions.PermissionValue;
-import eu.xenit.apix.exceptions.FileExistsException;
 import eu.xenit.apix.rest.v1.ApixV1Webscript;
 import eu.xenit.apix.rest.v1.RestV1Config;
 import eu.xenit.apix.rest.v1.nodes.ChangeAclsOptions.Access;
@@ -629,7 +628,10 @@ public class NodesWebscript1 extends ApixV1Webscript {
                                         "Please provide parameter \"type\" when creating a new node");
                                 return null;
                             }
-                            metadataChanges = new MetadataChanges(type, null, null,
+
+                            metadataChanges = new MetadataChanges(type,
+                                    createNodeOptions.aspectsToAdd,
+                                    createNodeOptions.aspectsToRemove,
                                     createNodeOptions.properties);
                             nodeService.setMetadata(nodeRef, metadataChanges);
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-492

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
