### PR TITLE
ALFREDAPI-497: Re-enable composeDown after integrationTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 * [ALFREDAPI-492](https://xenitsupport.jira.com/browse/ALFREDAPI-492): /v1/nodes POST enpoint now accepts aspects to add/remove
+* [ALFREDAPI-497](https://xenitsupport.jira.com/browse/ALFREDAPI-497): Re-enable `composeDown` after `integrationTest` in build
 
 
 

--- a/apix-integrationtests/build.gradle
+++ b/apix-integrationtests/build.gradle
@@ -105,5 +105,10 @@ subprojects {
         compileOnly project(':apix-integrationtests')
     }
 
+    integrationTest {
+        // After the tests, the docker setup should be stopped
+        finalizedBy composeDownTask
+    }
+
 }
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-497

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
