### PR TITLE
ALFREDAPI-498 handle version nodes appropriately for sourceAssociations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Changed
 
+* [ALFREDAPI-498](https://xenitsupport.jira.com/browse/ALFREDAPI-497): improve handling of version node association retrieval
+
 ### Fixed
 
 

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/metadata/NodeService.java
@@ -411,14 +411,19 @@ public class NodeService implements INodeService {
 
     @Override
     public List<NodeAssociation> getSourceAssociations(eu.xenit.apix.data.NodeRef ref) {
-        return nodeService.getSourceAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL)
-                .stream()
-                .map(alfPeerAssoc ->
-                        new NodeAssociation(
-                                c.apix(alfPeerAssoc.getSourceRef()),
-                                ref,
-                                c.apix(alfPeerAssoc.getTypeQName())))
-                .collect(Collectors.toList());
+        // Versionstore does not support sourceAssocs. For version nodes, do not do call, add empty list to result
+        List<NodeAssociation> sourceAssocs = null;
+        if ("versionStore".equals(ref.getStoreRefProtocol())) {
+            sourceAssocs = nodeService.getSourceAssocs(c.alfresco(ref), RegexQNamePattern.MATCH_ALL)
+                    .stream()
+                    .map(alfPeerAssoc ->
+                            new NodeAssociation(
+                                    c.apix(alfPeerAssoc.getSourceRef()),
+                                    ref,
+                                    c.apix(alfPeerAssoc.getTypeQName())))
+                    .collect(Collectors.toList());
+        }
+        return sourceAssocs == null ? new ArrayList<>() : sourceAssocs;
     }
 
     @Override


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-498

Improve handling of version nodes in the getSourceAssociations call: alfresco does not support this operation on these nodes. Change ensure calls result into an empty result rather than an exception, with the benefit of maintaining old established behaviour.

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
