### PR TITLE
ALFREDAPI-520 enforce charencoding for clean response in bulk endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Alfred API - Changelog
 
-## 4.0.1 (yyyy-mm-dd)
+## 4.0.2 (yyyy-mm-dd)
 
 ### Added
 
 ### Changed
 
-
 ### Fixed
+* [ALFREDAPI-520](https://xenitsupport.jira.com/browse/ALFREDAPI-520): Enforce encoding on json responses to guarantee clean response in bulk webscript
 
 ### Removed
-
 
 ## 4.0.1 (unreleased)
 

--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/ApixV1Webscript.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/ApixV1Webscript.java
@@ -12,8 +12,10 @@ import eu.xenit.apix.permissions.IPermissionService;
 import eu.xenit.apix.permissions.PermissionValue;
 import eu.xenit.apix.rest.v1.nodes.NodeInfo;
 import eu.xenit.apix.rest.v1.nodes.NodeInfoRequest;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
@@ -26,7 +28,9 @@ public class ApixV1Webscript {
     private static final Logger logger = LoggerFactory.getLogger(ApixV1Webscript.class);
 
     protected <T> ResponseEntity<T> writeJsonResponse(T object) {
-        return ResponseEntity.ok(object);
+        return ResponseEntity.ok()
+                .contentType(new MediaType("application", "json", StandardCharsets.UTF_8))
+                .body(object);
     }
 
     protected NodeRef createNodeRef(String space, String store, String guid) {


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-520

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
