### PR TITLE
ALFREDAPI-523 fix configuration endpoint

### DIFF
--- a/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/configuration/ConfigurationWebscript1.java
+++ b/apix-rest-v1/src/main/java/eu/xenit/apix/rest/v1/configuration/ConfigurationWebscript1.java
@@ -6,24 +6,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gradecak.alfresco.mvc.annotation.AlfrescoAuthentication;
 import com.gradecak.alfresco.mvc.annotation.AlfrescoTransaction;
 import com.gradecak.alfresco.mvc.annotation.AuthenticationType;
+import com.gradecak.alfresco.mvc.webscript.DispatcherWebscript;
 import eu.xenit.apix.configuration.ConfigurationFileFlags;
 import eu.xenit.apix.configuration.ConfigurationService;
 import eu.xenit.apix.configuration.Configurations;
 import eu.xenit.apix.rest.v1.ApixV1Webscript;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @AlfrescoAuthentication(AuthenticationType.USER)
 @RestController
@@ -45,13 +48,14 @@ public class ConfigurationWebscript1 extends ApixV1Webscript {
     }
 
     @AlfrescoTransaction(readOnly = true)
-    @GetMapping(value = "/v1/configuration", consumes = {"application/js"}, produces = {"application/js"})
+    @GetMapping(value = "/v1/configuration", produces = {"application/js", MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<?> getJsConfigurationFiles(
             @RequestParam(defaultValue = "content,nodeRef", required = false) String[] fields,
             @RequestParam String searchDirectory,
             @RequestParam(value = "filter.name", required = false) String nameFilter,
-            @RequestParam(required = false) String callback
+            @RequestParam(required = false) String callback, final HttpServletRequest req
     ) throws IOException {
+        final WebScriptRequest wsReq = ((DispatcherWebscript.WebscriptRequestWrapper) req).getWebScriptServletRequest();
         List<String> fieldsList = Arrays.asList(fields);
         ConfigurationFileFlags configurationFileFlags = new ConfigurationFileFlags(
                 fieldsList.contains("content"),
@@ -61,32 +65,31 @@ public class ConfigurationWebscript1 extends ApixV1Webscript {
                 fieldsList.contains("nodeRef"));
         Configurations configurations = configurationService
                 .getConfigurationFiles(searchDirectory, nameFilter, configurationFileFlags);
+        if ("js".equalsIgnoreCase(wsReq.getFormat()) ||
+                "js".equalsIgnoreCase(
+                        getAcceptSubType(
+                                req.getHeader("Accept")))) {
+            return ResponseEntity.ok()
+                    .contentType(new MediaType("application", "js"))
+                    .body(
+                            String.format("%s(%s)", callback,
+                                    mapper.writeValueAsString(configurations)));
+        }
         return ResponseEntity.ok()
-                .body(
-                        String.format("%s(%s)", callback,
-                                mapper.writeValueAsString(configurations)));
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(configurations);
     }
 
-    @AlfrescoTransaction(readOnly = true)
-    @GetMapping(value = "/v1/configuration" ,
-            consumes = {MediaType.APPLICATION_JSON_VALUE},
-            produces = {MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<?> getConfigurationFiles(
-            @RequestParam(defaultValue = "content,nodeRef", required = false) String[] fields,
-            @RequestParam String searchDirectory,
-            @RequestParam(value = "filter.name", required = false) String nameFilter
-    ) throws IOException {
-        List<String> fieldsList = Arrays.asList(fields);
-        ConfigurationFileFlags configurationFileFlags = new ConfigurationFileFlags(
-                fieldsList.contains("content"),
-                fieldsList.contains("path"),
-                fieldsList.contains("parsedContent"),
-                fieldsList.contains("metadata"),
-                fieldsList.contains("nodeRef"));
-        Configurations configurations = configurationService
-                .getConfigurationFiles(searchDirectory, nameFilter, configurationFileFlags);
-        return ResponseEntity.ok()
-                .body(configurations);
+    @Nullable
+    private static String getAcceptSubType(String accept) {
+        String acceptSubType = null;
+        if (accept != null) {
+            String[] acceptSplit = accept.split("/");
+            if (acceptSplit.length > 1) {
+                acceptSubType = acceptSplit[1];
+            }
+        }
+        return acceptSubType;
     }
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-<**YOUR TICKET ID**>

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/stable-user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
