### PR TITLE
ALFREDAPI-538 Fixed issue where errors related to jackson libraries would show up in the Alfresco logs while starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Alfred API - Changelog
 
-## 5.0.0 (unreleased - yyyy-MM-dd)
+## 5.0.1 (unreleased - yyyy-MM-dd)
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Alfred API - Changelog
 
+## 5.0.0 (unreleased - yyyy-MM-dd)
+### Added
+
+### Changed
+
+### Fixed
+* [ALFREDAPI-538](https://xenitsupport.jira.com/browse/ALFREDAPI-538): Fixed issue where errors related to jackson library conflicts would occurs while Alfresco is running
+
+### Removed
+
+
 ## 5.0.0 (2023-12-12)
 From this version onward Dynamic Extensions is replaced by [Alfresco MVC](https://github.com/dgradecak/alfresco-mvc)
 as framework to reduce maintenance efforts.

--- a/apix-impl/build.gradle
+++ b/apix-impl/build.gradle
@@ -1,4 +1,8 @@
-sourceSets.main.java.srcDirs += 'src/main/java'
+apply plugin: 'java-library'
+dependencies {
+    api project(":apix-interface")
+    implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
+}
 subprojects {
     def shortAlfrescoVersion = project.name.split("-")[2]
     apply from: "${rootProject.projectDir}/alfresco/${shortAlfrescoVersion}/overrides.gradle"
@@ -33,23 +37,16 @@ allprojects {
     apply plugin: 'java-library'
 
     dependencies {
-        api(project(":apix-interface")) {
-            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
-            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-        }
-        implementation group: 'commons-lang', name: 'commons-lang', version: '1.0'
-        implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
-        implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.0'
-
         alfrescoProvided platform("org.alfresco:acs-community-packaging:${alfresco_version}")
         alfrescoProvided "org.alfresco:alfresco-repository"
         alfrescoProvided 'org.alfresco:alfresco-remote-api'
+        alfrescoProvided 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
         testImplementation platform("org.alfresco:acs-community-packaging:${alfresco_version}")
         testImplementation 'org.alfresco:alfresco-repository'
         testImplementation 'org.alfresco:alfresco-remote-api'
         testImplementation 'org.alfresco:alfresco-data-model'
-        testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.25.1'
+        testImplementation 'org.mockito:mockito-core'
     }
 
     task generateVersionFile(type: Task) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def static getVersionQualifier(String branch_name) {
 }
 
 ext {
-    versionWithoutQualifier = '5.0.0'
+    versionWithoutQualifier = '5.0.1'
 
     de_version = '3.1.0' // Only used for integration testing
     mvc = '8.0.0'


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-538

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
