### PR TITLE
Alfredapi 540/artifactnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Alfred API - Changelog
 
 ## 5.0.1 (unreleased - yyyy-MM-dd)
+
+The artifact name of `apix-interface` has been changed to `alfred-api-interface`.
+
 ### Added
 
 ### Changed
@@ -8,6 +11,7 @@
 ### Fixed
 * [ALFREDAPI-537](https://xenitsupport.jira.com/browse/ALFREDAPI-537): Fix conflicts between artifacts when publishing to Sonatype
 * [ALFREDAPI-538](https://xenitsupport.jira.com/browse/ALFREDAPI-538): Fixed issue where errors related to jackson library conflicts would occurs while Alfresco is running
+* [ALFREDAPI-540](https://xenitsupport.jira.com/browse/ALFREDAPI-540): Realign interface artifact name
 
 ### Removed
 

--- a/apix-interface/build.gradle
+++ b/apix-interface/build.gradle
@@ -15,6 +15,7 @@ task javadocJar(type: Jar) {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifactId 'alfred-api-interface'
             from components.java
             artifact sourcesJar
             artifact javadocJar

--- a/apix-interface/build.gradle
+++ b/apix-interface/build.gradle
@@ -25,6 +25,6 @@ publishing {
 dependencies {
     compileOnly "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     compileOnly "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
 }
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-540

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
