### PR TITLE
[ALFREDAPI-543]: preparation for release 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Alfred API - Changelog
 
-## 5.0.1 (unreleased - yyyy-MM-dd)
+## 5.0.1 (2024-03-19)
 
 The artifact name of `apix-interface` has been changed to `alfred-api-interface`.
 


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/ALFREDAPI-543

XEP-11 mentions that the `build.gradle` file should also be updated; however, this file is already pointing to version '5.0.1'.
