### PR TITLE
ALFREDAPI-547 add validation to for facet size

### DIFF
--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/temp/V1SearchWebscriptTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/temp/V1SearchWebscriptTest.java
@@ -2,8 +2,8 @@ package eu.xenit.apix.rest.v1.tests.temp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xenit.apix.rest.v1.tests.RestV1BaseTest;
+import eu.xenit.apix.search.FacetSearchResult;
 import eu.xenit.apix.search.SearchQueryResult;
-import java.io.IOException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -14,6 +14,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 
 /**
@@ -52,6 +54,10 @@ public class V1SearchWebscriptTest extends RestV1BaseTest {
         logger.debug(String.valueOf(result));
         logger.debug(String.valueOf(result.getTotalResultCount()));
         Assert.assertFalse(result.getFacets().isEmpty());
+        for (FacetSearchResult facet : result.getFacets()) {
+            Assert.assertFalse(facet.getValues().isEmpty());
+            Assert.assertTrue(facet.getValues().size() <= 5);
+        }
         Assert.assertFalse(result.getNoderefs().isEmpty());
         Assert.assertFalse(result.getTotalResultCount() == 0L);
     }


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-<**YOUR TICKET ID**>

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
