### PR TITLE
ALFREDAPI-545 Defects and improvements v4.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_CENTRAL_GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.SONATYPE_S01_USERNAME }}
           ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.SONATYPE_S01_PASSWORD }}
+          BRANCH_NAME: ${{ github.head_ref }}
         with:
           arguments: >-
             --info -PsigningKeyId=DF8285F0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,10 @@ jobs:
         uses: mikepenz/action-junit-report@v3.7.6
         if: success() || failure()
         with:
-          check_name: 'test_reports'
+          check_name: "test-reports-${{ matrix.alfresco_version }}"
           report_paths: '**/build/test-results/**/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          detailed_summary: true
 
       - name: Publish
         if: ${{ startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/release') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,14 @@ jobs:
           name: test-result
           path: /home/runner/work/**/build/reports
           retention-days: 2
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3.7.6
+        if: success() || failure()
+        with:
+          check_name: 'test_reports'
+          report_paths: '**/build/test-results/**/TEST-*.xml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish
         if: ${{ startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/release') }}
         uses: gradle/gradle-build-action@v2.3.0
@@ -61,7 +69,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_CENTRAL_GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.SONATYPE_S01_USERNAME }}
           ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.SONATYPE_S01_PASSWORD }}
-          BRANCH_NAME: ${{ github.head_ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
         with:
           arguments: >-
             --info -PsigningKeyId=DF8285F0

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ out/
 **/.project
 **/.classpath
 **/.settings/
-
+.vscode/
 
 # EDITOR
 npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Alfred API - Changelog
 
 
-## 4.0.2 (unreleased)
+## 4.1.0 (unreleased)
 
 
 ### Added
 ### Changed
 ### Fixed
+* [ALFREDAPI-546](https://xenitsupport.jira.com/browse/ALFREDAPI-546): Fix facet qname splitting for dates (cfr. [ALFREDAPI-531])
+
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,11 @@
 # Alfred API - Changelog
 
 
-## 4.1.1 (unreleased)
+## 4.1.1 (2024-04-25)
 
-### Added
-### Changed
 ### Fixed
 * [ALFREDAPI-547](https://xenitsupport.jira.com/browse/ALFREDAPI-547): Implemented use of maxFilters in facet configuration
-
-## 4.1.0 (unreleased)
-
-### Added
-### Changed
-### Fixed
-* [ALFREDAPI-546](https://xenitsupport.jira.com/browse/ALFREDAPI-546): Fix facet qname splitting for dates (cfr. [ALFREDAPI-531])
-
-### Removed
+* [ALFREDAPI-546](https://xenitsupport.jira.com/browse/ALFREDAPI-546): Facet qname splitting for dates (cfr. [ALFREDAPI-546](https://xenitsupport.jira.com/browse/ALFREDAPI-546))
 
 
 ## 4.0.1 (2023-06-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Alfred API - Changelog
 
 
+## 4.0.2 (unreleased)
+
+
+### Added
+### Changed
+### Fixed
+### Removed
+
+
 ## 4.0.1 (2023-06-13)
 This release removes swaggerui_5x from alfred-api artifact and changes generation of Snapshot qualifier to comform to maven format.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Alfred API - Changelog
 
 
-## 4.1.0 (unreleased)
+## 4.1.1 (unreleased)
 
+### Added
+### Changed
+### Fixed
+* [ALFREDAPI-547](https://xenitsupport.jira.com/browse/ALFREDAPI-547): Implemented use of maxFilters in facet configuration
+
+## 4.1.0 (unreleased)
 
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Alfred API - Changelog
 
+**Announcement**
+
+Alfred API v4 and older are currently in End of Life.  
+We are moving away from the [Dynamic Extensions](https://github.com/xenit-eu/dynamic-extensions-for-alfresco) platform towards [Alfresco MVC](https://github.com/dgradecak/alfresco-mvc) platform to reduce our maintenance efforts.  
+Please follow the [installation gude](https://docs.xenit.eu/alfred-api/user/installation/) to upgrade to Alfred API v5+.
 
 ## 4.1.1 (2024-04-25)
 

--- a/apix-docker/62/build.gradle
+++ b/apix-docker/62/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:6.2.2.19")
-    baseAlfrescoWar 'org.alfresco:content-services:6.2.2.19@war'
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:6.2.2.25")
+    baseAlfrescoWar 'org.alfresco:content-services:6.2.2.25@war'
     // Fix for https://github.com/xenit-eu/dynamic-extensions-for-alfresco#alfresco-61---wrong-version-of-commons-annotations-used
     alfrescoAmp(group: 'eu.xenit.alfresco', name: 'alfresco-hotfix-MNT-20557', version: '1.0.2', ext: 'amp')
 }
 
 dockerAlfresco {
-    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2.19'
+    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2.25'
 }

--- a/apix-docker/70/build.gradle
+++ b/apix-docker/70/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.0.1.3")
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.0.1.9")
     baseAlfrescoWar 'org.alfresco:content-services@war'
 }
 
 dockerAlfresco {
-    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.1.3'
+    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.1.9'
 }

--- a/apix-docker/71/build.gradle
+++ b/apix-docker/71/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.1.0")
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.1.0.6")
     baseAlfrescoWar 'org.alfresco:content-services@war'
 }
 
 dockerAlfresco {
-    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.1'
+    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.1.0.6'
 }

--- a/apix-docker/72/build.gradle
+++ b/apix-docker/72/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.2.0")
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.2.1.13")
     baseAlfrescoWar 'org.alfresco:content-services@war'
 }
 
 dockerAlfresco {
-    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.2'
+    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.2.1.13'
 }

--- a/apix-docker/73/build.gradle
+++ b/apix-docker/73/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.3.0.1")
+    baseAlfrescoWar platform("org.alfresco:acs-packaging:7.3.1.2")
     baseAlfrescoWar 'org.alfresco:content-services@war'
 }
 
 dockerAlfresco {
-    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.3.0.1'
+    baseImage = 'private.docker.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.3.1.2'
 }

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -47,12 +47,12 @@ import org.springframework.stereotype.Component;
 public class SearchFacetsServiceImpl implements SearchFacetsService {
 
     private static final Logger logger = LoggerFactory.getLogger(SearchFacetsServiceImpl.class);
-    private FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry;
-    private SolrFacetHelper solrFacetHelper;
-    private DictionaryService dictionaryService;
-    private NodeService nodeService;
-    private SolrFacetService facetService;
-    private ITranslationService translationService;
+    private final FacetLabelDisplayHandlerRegistry facetLabelDisplayHandlerRegistry;
+    private final SolrFacetHelper solrFacetHelper;
+    private final DictionaryService dictionaryService;
+    private final NodeService nodeService;
+    private final SolrFacetService facetService;
+    private final ITranslationService translationService;
 
     // This file might give inspection error due to being 5.x specific.
     // Intellij can't handle this file being reused in different libs.
@@ -248,8 +248,8 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             // facetTokenName => @{http://www.alfresco.org/model/content/1.0}created
             // qName => {http://www.alfresco.org/model/content/1.0}created
             // 7 => {!afts}
-            key = key.substring(7);
-            String facetTokenName = key.substring(0, key.lastIndexOf(':'));
+            key = key.replace("{!afts}","");
+            String facetTokenName = key.substring(0, key.indexOf(":["));
             String qName = facetTokenToQname(facetTokenName);
 
             // Retrieve the previous facet queries
@@ -260,7 +260,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
 
             // Get the handler for this qName
             FacetLabelDisplayHandler handler = facetLabelDisplayHandlerRegistry.getDisplayHandler(facetTokenName);
-            String val = key.substring(key.indexOf('}') + key.substring(key.indexOf('}')).indexOf(':') + 1);
+            String val = key.substring(key.indexOf(":[") + 1);
             FacetLabel facetLabel = (handler == null) ? new FacetLabel(val, val, -1) : handler.getDisplayLabel(key);
 
             // See if we have a nice textual version of this label

--- a/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/alfresco/search/SearchFacetsServiceImpl.java
@@ -111,7 +111,7 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
             if (facetQName == null) {
                 logger.error("Facet with id ({}) has a facetQName of null. "
                         + "This configured facet does not correctly link to a property in the document model."
-                        + "\n Facet field config: {}", field.getFilterID(), field.toString());
+                        + "\n Facet field config: {}", field.getFilterID(), field);
                 continue;
             }
 
@@ -170,11 +170,9 @@ public class SearchFacetsServiceImpl implements SearchFacetsService {
                 } else {
                     fieldFacet = new SearchParameters.FieldFacet(fieldId);
                 }
-//TODO: set limit
-//                if (facetLimit != null)
-//                    fieldFacet.setLimit(facetLimit);
-//                if (facetMinCount != null)
-//                    fieldFacet.setMinCount(facetMinCount);
+
+                fieldFacet.setMinCount(field.getHitThreshold());
+                fieldFacet.setLimitOrNull(field.getMaxFilters());
 
                 sp.addFieldFacet(fieldFacet);
             }

--- a/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
+++ b/apix-impl/src/test/java/eu/xenit/apix/tests/search/SearchFacetServiceUnitTest.java
@@ -15,6 +15,7 @@ import eu.xenit.apix.translation.ITranslationService;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.alfresco.repo.dictionary.constraint.ListOfValuesConstraint;
 import org.alfresco.repo.search.impl.solr.facet.SolrFacetHelper;
@@ -110,7 +111,11 @@ public class SearchFacetServiceUnitTest {
                 .thenReturn(languageFieldFacetResults);
         when(resultSetMock.getFieldFacet("@{http://test.apix.xenit.eu/model/content}documentStatus"))
                 .thenReturn(documentStatusFieldFacetResults);
-        when(resultSetMock.getFacetQueries()).thenReturn(new HashMap<String, Integer>());
+        Map<String, Integer> facetQueries = new HashMap<>();
+        facetQueries.put("{!afts}@{http://www.alfresco.org/model/content/1.0}content.size:[0 TO 10240]", 1);
+        facetQueries.put("{!afts}@{http://www.alfresco.org/model/content/1.0}modified:[NOW/DAY-1YEAR TO NOW/DAY+1DAY]", 2);
+        facetQueries.put("{!afts}@{http://www.alfresco.org/model/content/1.0}created:[2020-08-31T07:00:00.000Z TO 2023-09-02T10:01:00.000Z]", 1);
+        when(resultSetMock.getFacetQueries()).thenReturn(facetQueries);
 
         searchParametersMock = mock(SearchParameters.class);
         List<FieldFacet> fieldFacets = new ArrayList<>();
@@ -145,6 +150,33 @@ public class SearchFacetServiceUnitTest {
         documentStatusValues.add(draftFacetValue);
         documentStatusResult.setValues(documentStatusValues);
         expectedResult.add(documentStatusResult);
+        FacetSearchResult contentResult = new FacetSearchResult();
+        contentResult.setName("{http://www.alfresco.org/model/content/1.0}content.size");
+        List<FacetValue> contentValues = new ArrayList<>();
+        FacetValue contentFacetValue = new FacetValue();
+        contentFacetValue.setValue("[0 TO 10240]");
+        contentFacetValue.setCount(1);
+        contentValues.add(contentFacetValue);
+        contentResult.setValues(contentValues);
+        expectedResult.add(contentResult);
+        FacetSearchResult modifiedResult = new FacetSearchResult();
+        modifiedResult.setName("{http://www.alfresco.org/model/content/1.0}modified");
+        List<FacetValue> modifiedValues = new ArrayList<>();
+        FacetValue modifiedFacetValue = new FacetValue();
+        modifiedFacetValue.setValue("[NOW/DAY-1YEAR TO NOW/DAY+1DAY]");
+        modifiedFacetValue.setCount(2);
+        modifiedValues.add(modifiedFacetValue);
+        modifiedResult.setValues(modifiedValues);
+        expectedResult.add(modifiedResult);
+        FacetSearchResult createdResult = new FacetSearchResult();
+        createdResult.setName("{http://www.alfresco.org/model/content/1.0}created");
+        List<FacetValue> createdValues = new ArrayList<>();
+        FacetValue createdFacetValue = new FacetValue();
+        createdFacetValue.setValue("[2020-08-31T07:00:00.000Z TO 2023-09-02T10:01:00.000Z]");
+        createdFacetValue.setCount(1);
+        createdValues.add(createdFacetValue);
+        createdResult.setValues(createdValues);
+        expectedResult.add(createdResult);
         return expectedResult;
     }
 

--- a/apix-integrationtests/build.gradle
+++ b/apix-integrationtests/build.gradle
@@ -120,4 +120,3 @@ subprojects {
     }
 
 }
-

--- a/apix-integrationtests/build.gradle
+++ b/apix-integrationtests/build.gradle
@@ -120,3 +120,4 @@ subprojects {
     }
 
 }
+

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/temp/V1SearchWebscriptTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/rest/v1/tests/temp/V1SearchWebscriptTest.java
@@ -2,8 +2,8 @@ package eu.xenit.apix.rest.v1.tests.temp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xenit.apix.rest.v1.tests.RestV1BaseTest;
+import eu.xenit.apix.search.FacetSearchResult;
 import eu.xenit.apix.search.SearchQueryResult;
-import java.io.IOException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -14,6 +14,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 
 /**
@@ -52,6 +54,10 @@ public class V1SearchWebscriptTest extends RestV1BaseTest {
         logger.debug(String.valueOf(result));
         logger.debug(String.valueOf(result.getTotalResultCount()));
         Assert.assertFalse(result.getFacets().isEmpty());
+        for (FacetSearchResult facet : result.getFacets()) {
+            Assert.assertFalse(facet.getValues().isEmpty());
+            Assert.assertTrue(facet.getValues().size() <= 5);
+        }
         Assert.assertFalse(result.getNoderefs().isEmpty());
         Assert.assertFalse(result.getTotalResultCount() == 0L);
     }

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/search/SearchServiceFacetsTest.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/search/SearchServiceFacetsTest.java
@@ -162,7 +162,7 @@ public class SearchServiceFacetsTest extends SearchServiceTest {
         query.setFacets(options);
 
         SearchQueryResult result = searchService.query(query);
-        // Search in results (Because of alf 4.2 source language level is 1.7. No lambdas to make this pretty 🙁)
+        // Search in results (Because of alf 4.2 source language level is 1.7. No lambdas to make this pretty :-))
         for (FacetSearchResult facetResult : result.getFacets()) {
             String facetName = facetResult.getName();
             if (bucketedFacetNames.contains(facetName)) {

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
@@ -36,10 +36,12 @@ public class WorkflowService_SearchContextMyPooledTasks_Test extends WorkflowSer
     }
 
     @Test
-    public void testDummy(){
-        logger.debug("dummytest: NoRunableMethodExceptionExample: solves race condition of  testSearchContextMyPooledTask");
-        assertEquals(1,1);
+    public void testDummy() {
+        logger.debug(
+                "dummytest: NoRunableMethodExceptionExample: solves race condition of  testSearchContextMyPooledTask");
+        assertEquals(1, 1);
     }
+
     @Test
     public void testSearchContextMyPooledTask() {
         String testName = new Object() {

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
@@ -39,7 +39,7 @@ public class WorkflowService_SearchContextMyPooledTasks_Test extends WorkflowSer
 
     @Test
     public void testDummy(){
-        System.out.println("test to resolve: NoRunableMethodExceptionExample: to Delete");
+        logger.debug("dummytest: NoRunableMethodExceptionExample: solves race condition of  testSearchContextMyPooledTask");
         assertEquals(1,1);
     }
     @Test

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
@@ -11,9 +11,7 @@ import java.util.Map;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.cmr.workflow.WorkflowPath;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.cmr.workflow.WorkflowPath;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,11 @@ public class WorkflowService_SearchContextMyPooledTasks_Test extends WorkflowSer
     }
 
     @Test
+    public void testDummy(){
+        System.out.println("test to resolve: NoRunableMethodExceptionExample: to Delete");
+        assertEquals(1,1);
+    }
+    @Ignore("Disabled for GHA build")
     public void testSearchContextMyPooledTask() {
         String testName = new Object() {
         }.getClass().getEnclosingMethod().getName();
@@ -45,7 +51,11 @@ public class WorkflowService_SearchContextMyPooledTasks_Test extends WorkflowSer
 
         TaskSearchQuery searchQuery = createNewSearchQuery(TaskSearchQuery.QueryScope.MyPooledTasks, 0, 5,
                 Sorting.ASCENDING, IWorkflowService.ALFRESCO_STARTDATE);
-
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         TaskOrWorkflowSearchResult result = getSearchResultTasks(searchQuery);
         assertEquals(2, result.results.size());
     }

--- a/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
+++ b/apix-integrationtests/src/main/java/eu/xenit/apix/tests/workflow/methods/WorkflowService_SearchContextMyPooledTasks_Test.java
@@ -13,6 +13,7 @@ import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.cmr.workflow.WorkflowPath;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ public class WorkflowService_SearchContextMyPooledTasks_Test extends WorkflowSer
         System.out.println("test to resolve: NoRunableMethodExceptionExample: to Delete");
         assertEquals(1,1);
     }
-    @Ignore("Disabled for GHA build")
+    @Test
     public void testSearchContextMyPooledTask() {
         String testName = new Object() {
         }.getClass().getEnclosingMethod().getName();
@@ -51,11 +52,7 @@ public class WorkflowService_SearchContextMyPooledTasks_Test extends WorkflowSer
 
         TaskSearchQuery searchQuery = createNewSearchQuery(TaskSearchQuery.QueryScope.MyPooledTasks, 0, 5,
                 Sorting.ASCENDING, IWorkflowService.ALFRESCO_STARTDATE);
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+
         TaskOrWorkflowSearchResult result = getSearchResultTasks(searchQuery);
         assertEquals(2, result.results.size());
     }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 }
 
 ext {
-    versionWithoutQualifier = '4.1.0'
+    versionWithoutQualifier = '4.1.1'
 
     jackson_version = '2.8.3'
     swagger_version = "1.5.7"

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 }
 
 ext {
-    versionWithoutQualifier = '4.0.2'
+    versionWithoutQualifier = '4.1.0'
 
     jackson_version = '2.8.3'
     swagger_version = "1.5.7"

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ subprojects {
                 password System.env.CLOUDSMITH_APIKEY ?: property('eu.xenit.cloudsmith.password')
             }
         }
+        maven {
+            url "https://repo.xenit.eu/zRCLvpH8FA0bR2ha/legacy/maven/"
+        }
         // This private repository provides Xenit with Alfresco enterprise artefacts.
         // External developers should replace it with their own library repository.
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -83,9 +83,6 @@ subprojects {
                 password System.env.CLOUDSMITH_APIKEY ?: property('eu.xenit.cloudsmith.password')
             }
         }
-        maven {
-            url "https://repo.xenit.eu/zRCLvpH8FA0bR2ha/legacy/maven/"
-        }
         // This private repository provides Xenit with Alfresco enterprise artefacts.
         // External developers should replace it with their own library repository.
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 }
 
 ext {
-    versionWithoutQualifier = '4.0.1'
+    versionWithoutQualifier = '4.0.2'
 
     jackson_version = '2.8.3'
     swagger_version = "1.5.7"

--- a/de-swagger-reader/build.gradle
+++ b/de-swagger-reader/build.gradle
@@ -3,6 +3,8 @@ description = 'Xenit Dynamic-extensions Swagger Reader'
 
 apply plugin: 'osgi'
 
+configurations.testImplementation.extendsFrom configurations.compileOnly
+
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.0.1'
     compile(group: 'io.swagger', name: 'swagger-core', version: swagger_version) {
@@ -15,4 +17,5 @@ dependencies {
     }
     compileOnly(group: 'org.springframework', name: 'spring-core', version: '3.2.10.RELEASE')
     compileOnly(group: 'org.springframework.extensions.surf', name: 'spring-webscripts', version: '5.0.d')
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
Includes tickets from https://xenitsupport.jira.com/browse/ALFREDAPI-545 (epic)
- Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-546
- Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-547

- [X] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [X] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [X] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [X] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [X] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [X] Is usage of `this.` prefix avoided?

@WimCrols this PR is the merge of 3 smaller PRs

Includes:
- https://github.com/xenit-eu/alfred-api/pull/203
- https://github.com/xenit-eu/alfred-api/pull/204
- https://github.com/xenit-eu/alfred-api/pull/205

There are 2 main regressions:
- Searching on date range breaks the date facet
- Alfred API does not use the maxFilters configuration to return the pre-configured number of facets, and defaults to 100