### PR TITLE
[ALFREDAPI-554] make service beans available in main application context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Alfred API - Changelog
 
+## 5.0.3 (2024-06-14)
+
+### Fixed
+
+* [ALFREDAPI-554](https://xenitsupport.jira.com/browse/ALFREDAPI-554): expose `apix-impl`
+beans in main application context (to be used by other AMPs)
+
 ## 5.0.2 (2024-05-14)
 
 ### Fixed

--- a/apix-impl/src/main/java/eu/xenit/apix/SpringConfiguration.java
+++ b/apix-impl/src/main/java/eu/xenit/apix/SpringConfiguration.java
@@ -4,9 +4,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(basePackageClasses = {
-        Version.class,
-})
+@ComponentScan(basePackages = {"eu.xenit.apix.alfresco"})
 public class SpringConfiguration {
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def static getVersionQualifier(String branch_name) {
 }
 
 ext {
-    versionWithoutQualifier = '5.0.2'
+    versionWithoutQualifier = '5.0.3'
 
     de_version = '3.1.0' // Only used for integration testing
     mvc = '8.0.0'

--- a/src/config/module-context.xml
+++ b/src/config/module-context.xml
@@ -10,4 +10,6 @@
             </list>
         </property>
     </bean>
+
+    <bean class="eu.xenit.apix.SpringConfiguration"/>
 </beans>


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/ALFREDAPI-554

Problem: Alfred API's service beans (e.g. ISearchService) are present in a separate child application context, making them unavailable for AMPs to be used.

This PR makes the beans of the `apix-impl` subproject available in the main application context of Alfresco, which Alfresco also uses when initializing beans of AMPs.

**Note to the reviewer:** I noticed that running the `test` Gradle task does not work. The following problems occur:
TypeServiceUnitTest:
	- testGetTypeDefinition_returnsNull_whenQnameInvalid
SetMetadataUnitTest:
	- testGeneralizeTypeWithCleanUpEnabled
	- testGeneralizeTypeWithCleanUpdisabled
SearchFacetServiceUnitTest:
	- assertThat_getFacetResults_returnIncludes_translationsForListOfValueConstraints
SearchServiceUnitTest:
	- all tests, except for testDefaultSearchQueryConsistencyIsTransactionalIfPossible
However, I noticed the same problem when running these tests on the master branch. These errors do not represent a new bug introduced by this PR.