### PR TITLE
ALFREDAPI-563-get-content [Update] Fix @GetMapping(value = "/v1/nodes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Alfred API - Changelog
 
+* [ALFREDAPI-563](https://xenitsupport.jira.com/browse/ALFREDAPI-563) Fix @GetMapping(value = "/v1/nodes/{space}/{store}/{guid}/content") Content-Type
+
 
 ## 6.0.0 (2024-08-22)
 From this version onward Dynamic Extensions for integration-testing is replaced by [remote-junit](https://github.com/ruediste/remote-junit)

--- a/alfred-api-rest/src/main/java/eu/xenit/alfred/api/rest/v1/nodes/NodesWebscript1.java
+++ b/alfred-api-rest/src/main/java/eu/xenit/alfred/api/rest/v1/nodes/NodesWebscript1.java
@@ -509,6 +509,7 @@ public class NodesWebscript1 extends AlfredApiV1Webscript {
             return writeNotFoundResponse(nodeRef);
         }
         return ResponseEntity.ok()
+                .header("Content-Type", contentInputStream.getMimetype())
                 .body(new InputStreamResource(contentInputStream.getInputStream()));
     }
 


### PR DESCRIPTION
…/{space}/{store}/{guid}/content") Content-Type

  * Add integration-test check for content-type.

Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-563

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
