### PR TITLE
ALFREDAPI-563 [Release] Release v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Alfred API - Changelog
 
+
+## 6.0.1 (2024-11-25)
+
+### Fixed
 * [ALFREDAPI-563](https://xenitsupport.jira.com/browse/ALFREDAPI-563) Fix @GetMapping(value = "/v1/nodes/{space}/{store}/{guid}/content") Content-Type
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ def static getVersionQualifier(String branch_name) {
 }
 
 ext {
-    versionWithoutQualifier = '6.0.0'
+    versionWithoutQualifier = '6.0.1'
 
     mvc = '9.0.0'
     jackson_version = '2.15.2'


### PR DESCRIPTION
  * Fix @GetMapping(value = "/v1/nodes/{space}/{store}/{guid}/content") Content-Type

Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-ALFREDAPI-563

- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
