### PR TITLE
Alfredapi 568: Set Tomcat casual multipart to true for integration testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 * [ALFREDAPI-563](https://xenitsupport.jira.com/browse/ALFREDAPI-563) Fix @GetMapping(value = "/v1/nodes/{space}/{store}/{guid}/content") Content-Type
+* [ALFREDAPI-568](https://xenitsupport.jira.com/browse/ALFREDAPI-568) Make Alfred API work with new Tomcat base image
+environment variable for casual multipart parsing
 
 ### Removed
 

--- a/alfred-api-docker/231/docker-compose.yml
+++ b/alfred-api-docker/231/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   alfresco-core:
     image: ${DOCKER_IMAGE:-image_not_set}

--- a/alfred-api-docker/231/docker-compose.yml
+++ b/alfred-api-docker/231/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - SOLR_HOST=solr
       - TERM=xterm
+      - TOMCAT_ALLOW_CASUAL_MULTIPART_PARSING=true
       - GLOBAL_messaging.broker.url=failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true
       - GLOBAL_localTransform.core-aio.url=http://transform-core-aio:8090/
   solr:

--- a/alfred-api-docker/232/docker-compose.yml
+++ b/alfred-api-docker/232/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   alfresco-core:
     image: ${DOCKER_IMAGE:-image_not_set}

--- a/alfred-api-docker/232/docker-compose.yml
+++ b/alfred-api-docker/232/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - SOLR_HOST=solr
       - TERM=xterm
+      - TOMCAT_ALLOW_CASUAL_MULTIPART_PARSING=true
       - GLOBAL_messaging.broker.url=failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true
       - GLOBAL_localTransform.core-aio.url=http://transform-core-aio:8090/
   solr:

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -743,6 +743,11 @@ Further details can be found on its [README](https://github.com/dgradecak/alfres
 [Dynamic Extensions For Alfresco](https://github.com/xenit-eu/dynamic-extensions-for-alfresco).
 Since version 5.0.0, however, Dynamic Extensions is no longer needed.)
 
+For the `/upload` REST endpoint to work correctly, the Tomcat server running Alfresco needs to have
+[casual multipart parsing](https://tomcat.apache.org/tomcat-8.5-doc/config/context.html#Common_Attributes) enabled.
+If you are using the [Xenit Alfresco base image](https://github.com/xenit-eu/docker-alfresco/), this can be done by
+setting `TOMCAT_ALLOW_CASUAL_MULTIPART_PARSING=true`.
+
 
 ### Install with Gradle
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-568

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Are all Alfresco services wired via ServiceRegistry (and not per service)?
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
