### PR TITLE
ALFREDAPI-570 Release Alfred API v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,18 @@
 # Alfred API - Changelog
 
-
-## 6.0.1 (UNRELEASED)
+## 6.1.0 (2025-04-01)
 ### Added
 [ALFREDAPI-548](https://xenitsupport.jira.com/browse/ALFREDAPI-569): Support Alfresco V23.3 && V23.4,
 
-### Changed
+### Fixed
+* [ALFREDAPI-568](https://xenitsupport.jira.com/browse/ALFREDAPI-568) Make Alfred API work with new Tomcat base image
+  environment variable for casual multipart parsing
+* [ALFREDAPI-568](https://xenitsupport.jira.com/browse/ALFREDAPI-568) Separated upload to native Alfresco webscript as a workaround to broken multipart upload with Alfresco MVC
+
+## 6.0.1 (2024-11-25)
 
 ### Fixed
 * [ALFREDAPI-563](https://xenitsupport.jira.com/browse/ALFREDAPI-563) Fix @GetMapping(value = "/v1/nodes/{space}/{store}/{guid}/content") Content-Type
-* [ALFREDAPI-568](https://xenitsupport.jira.com/browse/ALFREDAPI-568) Make Alfred API work with new Tomcat base image
-environment variable for casual multipart parsing
-* [ALFREDAPI-568](https://xenitsupport.jira.com/browse/ALFREDAPI-568) Separated upload to native Alfresco webscript as a workaround to broken multipart upload with Alfresco MVC
-
-### Removed
-
 
 ## 6.0.0 (2024-08-22)
 From this version onward Dynamic Extensions for integration-testing is replaced by [remote-junit](https://github.com/ruediste/remote-junit)

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ def static getVersionQualifier(String branch_name) {
 }
 
 ext {
-    versionWithoutQualifier = '6.0.1'
+    versionWithoutQualifier = '6.1.0'
 
     mvc = '9.0.0'
     jackson_version = '2.15.2'

--- a/docs/swagger-ui/swagger.json
+++ b/docs/swagger-ui/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "This is the swagger specification for Alfred REST API\n\nExamples can be found at: https://docs.xenit.eu/alfred-api",
-    "version": "5.0.3",
+    "version": "6.1.0",
     "title": "Alfred REST Api",
     "contact": {
       "name": "XeniT",


### PR DESCRIPTION
Release Alfred API v6.1.0: https://xenitsupport.jira.com/browse/ALFREDAPI-570
