### PR TITLE
ALFREDAPI-573: Fix broken Maven artifact badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 ![CI status](https://github.com/xenit-eu/alfred-api/actions/workflows/ci.yml/badge.svg)
-[![Maven Central](https://img.shields.io/maven-central/v/eu.xenit.alfred.api/apix-interface.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22eu.xenit.alfred.api%22%20AND%20a%3A%22apix-interface%22)
+[![Maven Central](https://img.shields.io/maven-central/v/eu.xenit.alfred.api/alfred-api-interface.svg)](https://central.sonatype.com/search?q=g:eu.xenit.alfred.api%20%20a:alfred-api-interface&smo=true)
 
 Alfred API abstracts away past and future changes to the Alfresco, across major and minor versions, providing a stable
 interface to Alfresco on which client-side applications can be built.


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-573
- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [ ] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [ ] Are all Alfresco services wired via ServiceRegistry (and not per service)?
- [ ] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [ ] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [ ] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [ ] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
