### PR TITLE
ALFREDAPI-575: Removed casual multipart paragraph from docs

### DIFF
--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -746,11 +746,6 @@ Further details can be found on its [README](https://github.com/dgradecak/alfres
 [Dynamic Extensions For Alfresco](https://github.com/xenit-eu/dynamic-extensions-for-alfresco).
 Since version 5.0.0, however, Dynamic Extensions is no longer needed.)
 
-For the `/upload` REST endpoint to work correctly, the Tomcat server running Alfresco needs to have
-[casual multipart parsing](https://tomcat.apache.org/tomcat-8.5-doc/config/context.html#Common_Attributes) enabled.
-If you are using the [Xenit Alfresco base image](https://github.com/xenit-eu/docker-alfresco/), this can be done by
-setting `TOMCAT_ALLOW_CASUAL_MULTIPART_PARSING=true`.
-
 
 ### Install with Gradle
 


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-575
- [ ] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Are all Alfresco services wired via ServiceRegistry (and not per service)?
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
