### PR TITLE
ALFREDAPI-581: Fix interface publish step conditional being ignored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           arguments: --info :alfred-api-rest:test
       - name: Publish
-        if: ${{ startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/release') }}"
+        if: ${{ startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/release') }}
         uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: --info -PsigningKeyId=CDE3528F :alfred-api-interface:publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 * [ALFREDAPI-578](https://xenitsupport.jira.com/browse/ALFREDAPI-578): Added Qualifiers to Conflicting beans with Governance Services
 * [ALFREDAPI-582](https://xenitsupport.jira.com/browse/ALFREDAPI-582): Migrate from Cloudsmith to Harbor
+* [ALFREDAPI-583](https://xenitsupport.jira.com/browse/ALFREDAPI-583): Fixed conditional step in publishing alfred-api-interface
 
 ## 6.1.0 (2025-04-01)
 ### Added


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-581

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Are all Alfresco services wired via ServiceRegistry (and not per service), and is ServiceRegistry autowired with `@Qualifier("ServiceRegistry")`?
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
