### PR TITLE
ALFREDAPI-580: Post-release bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Alfred API - Changelog
 
+## 6.1.3 (unreleased)
+
+### Added
+
+### Fixed
+
+
 ## 6.1.2 (2025-11-06)
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ def static getVersionQualifier(String branch_name) {
 }
 
 ext {
-    versionWithoutQualifier = '6.1.2'
+    versionWithoutQualifier = '6.1.3'
 
     mvc = '9.0.0'
     jackson_version = '2.15.2'

--- a/docs/swagger-ui/swagger.json
+++ b/docs/swagger-ui/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "This is the swagger specification for Alfred REST API\n\nExamples can be found at: https://docs.xenit.eu/alfred-api",
-    "version": "6.1.2",
+    "version": "6.1.3",
     "title": "Alfred REST Api",
     "contact": {
       "name": "XeniT",


### PR DESCRIPTION
Fixes https://xenitsupport.jira.com/browse/ALFREDAPI-580

- [x] Is [CHANGELOG.md](https://github.com/xenit-eu/alfred-api/blob/master/CHANGELOG.md) extended?
- [x] Does this PR avoid breaking the API? 
    Breaking changes include adding, changing or removing endpoints and/or JSON objects used in requests and responses.
- [x] Are all Alfresco services wired via ServiceRegistry (and not per service), and is ServiceRegistry autowired with `@Qualifier("ServiceRegistry")`?
- [x] Does the PR comply to REST HTTP result codes policy outlined in the [user guide](https://docs.xenit.eu/alfred-api/user/rest-api/index.html#rest-http-result-codes)?
- [x] Is error handling done through a method annotated with `@ExceptionHandler` in the webscript classes?
- [x] Does the PR follow our [coding styleguide and other active procedures](https://xenitsupport.jira.com/wiki/spaces/XEN/pages/624558081/XeniT+Enhancement+Proposals+XEP)?
- [x] Is usage of `this.` prefix avoided?

See [README.md](./README.md) for full explanation.
